### PR TITLE
Remove .beads/ from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@ dist/
 docs
 .npmrc
 .agents/
-.beads/
 .claude/
 .codex/
 .eni/


### PR DESCRIPTION
## Summary
- Remove `.beads/` entry from `.gitignore` since stealth mode now uses `.git/info/exclude` instead

## Test plan
- Verify `.beads/` is no longer in `.gitignore`
- Confirm stealth mode still works via `.git/info/exclude`