### PR TITLE
feat: dark-vole-94

### DIFF
--- a/src/core/cli-models.ts
+++ b/src/core/cli-models.ts
@@ -1,0 +1,133 @@
+import { execCommand } from './detect.js';
+import type { ExecResult } from './detect.js';
+import type { KnownModel } from '../types.js';
+import { createDebugLogger } from './debug.js';
+
+const log = createDebugLogger();
+
+// --- Error class ---
+
+export class CliModelsFetchError extends Error {
+  readonly kind: 'enoent' | 'timeout' | 'exit_code' | 'error';
+
+  constructor(
+    message: string,
+    kind: CliModelsFetchError['kind'],
+    options?: { cause?: Error },
+  ) {
+    super(message, options?.cause ? { cause: options.cause } : undefined);
+    this.name = 'CliModelsFetchError';
+    this.kind = kind;
+  }
+}
+
+// --- Type guard ---
+
+function isExecResult(result: Awaited<ReturnType<typeof execCommand>>): result is ExecResult {
+  return 'exitCode' in result;
+}
+
+// --- Parsing ---
+
+export function parseCliModelsOutput(stdout: string): KnownModel[] {
+  return stdout
+    .split('\n')
+    .map(line => line.trim())
+    .filter(line => line.length > 0)
+    .map(line => {
+      const slashIndex = line.indexOf('/');
+      const provider = slashIndex > 0 ? line.substring(0, slashIndex) : line;
+      return {
+        id: line,
+        name: line,
+        provider,
+        contextWindow: null,
+        supportsEffort: false,
+      };
+    });
+}
+
+// --- Fetch ---
+
+export async function fetchCliModels(): Promise<KnownModel[]> {
+  log?.('fetchCliModels: executing opencode models');
+  const result = await execCommand('opencode', ['models']);
+
+  if (!isExecResult(result)) {
+    switch (result.kind) {
+      case 'enoent':
+        throw new CliModelsFetchError('opencode binary not found', 'enoent');
+      case 'timeout':
+        throw new CliModelsFetchError('opencode models timed out', 'timeout');
+      case 'error':
+        throw new CliModelsFetchError('opencode models failed to spawn', 'error', {
+          cause: result.error instanceof Error ? result.error : new Error(String(result.error)),
+        });
+    }
+  }
+
+  if (result.exitCode !== 0) {
+    const detail = result.stderr ? `: ${result.stderr}` : '';
+    throw new CliModelsFetchError(
+      `opencode models exited with code ${result.exitCode}${detail}`,
+      'exit_code',
+    );
+  }
+
+  const models = parseCliModelsOutput(result.stdout);
+  log?.(`fetchCliModels: parsed ${models.length} models`);
+  return models;
+}
+
+// --- Cache ---
+
+export const CLI_MODELS_CACHE_TTL_MS = 24 * 60 * 60 * 1000;
+
+export interface CliModelsCache {
+  data: KnownModel[];
+  fetchedAt: number;
+}
+
+let cache: CliModelsCache | null = null;
+let inflight: Promise<CliModelsCache> | null = null;
+
+export async function ensureCliModelsCache(): Promise<CliModelsCache> {
+  if (cache && (Date.now() - cache.fetchedAt) < CLI_MODELS_CACHE_TTL_MS) {
+    log?.('ensureCliModelsCache: cache hit');
+    return cache;
+  }
+
+  if (inflight) {
+    log?.('ensureCliModelsCache: joining inflight request');
+    return inflight;
+  }
+
+  inflight = (async () => {
+    try {
+      const data = await fetchCliModels();
+      cache = { data, fetchedAt: Date.now() };
+      return cache;
+    } finally {
+      inflight = null;
+    }
+  })();
+
+  return inflight;
+}
+
+export async function refreshCliModelsCache(): Promise<CliModelsCache> {
+  log?.('refreshCliModelsCache: forcing refresh');
+  const data = await fetchCliModels();
+  cache = { data, fetchedAt: Date.now() };
+  return cache;
+}
+
+export function clearCliModelsCache(): void {
+  cache = null;
+  inflight = null;
+  log?.('clearCliModelsCache: cache cleared');
+}
+
+export function getCliModelsCache(): CliModelsCache | null {
+  return cache;
+}

--- a/src/core/cli-models.ts
+++ b/src/core/cli-models.ts
@@ -1,5 +1,5 @@
 import { execCommand } from './detect.js';
-import type { ExecResult } from './detect.js';
+import type { ExecResult, ExecError } from './detect.js';
 import type { KnownModel } from '../types.js';
 import { createDebugLogger } from './debug.js';
 
@@ -23,8 +23,8 @@ export class CliModelsFetchError extends Error {
 
 // --- Type guard ---
 
-function isExecResult(result: Awaited<ReturnType<typeof execCommand>>): result is ExecResult {
-  return 'exitCode' in result;
+function isExecError(result: ExecResult | ExecError): result is ExecError {
+  return 'kind' in result;
 }
 
 // --- Parsing ---
@@ -36,7 +36,7 @@ export function parseCliModelsOutput(stdout: string): KnownModel[] {
     .filter(line => line.length > 0)
     .map(line => {
       const slashIndex = line.indexOf('/');
-      const provider = slashIndex > 0 ? line.substring(0, slashIndex) : line;
+      const provider = slashIndex > 0 ? line.substring(0, slashIndex) : 'unknown';
       return {
         id: line,
         name: line,
@@ -53,7 +53,7 @@ export async function fetchCliModels(): Promise<KnownModel[]> {
   log?.('fetchCliModels: executing opencode models');
   const result = await execCommand('opencode', ['models']);
 
-  if (!isExecResult(result)) {
+  if (isExecError(result)) {
     switch (result.kind) {
       case 'enoent':
         throw new CliModelsFetchError('opencode binary not found', 'enoent');
@@ -107,6 +107,12 @@ export async function ensureCliModelsCache(): Promise<CliModelsCache> {
       const data = await fetchCliModels();
       cache = { data, fetchedAt: Date.now() };
       return cache;
+    } catch (err) {
+      if (cache) {
+        log?.('ensureCliModelsCache: fetch failed, returning stale cache');
+        return cache;
+      }
+      throw err;
     } finally {
       inflight = null;
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,13 +21,4 @@ export { spawn } from './core/spawn.js';
 export { extract } from './core/extract.js';
 export { classifyError, classifyErrorDefault, matchSharedPatterns, parseRetryAfterMs } from './core/errors.js';
 
-export {
-  fetchCliModels,
-  ensureCliModelsCache,
-  refreshCliModelsCache,
-  clearCliModelsCache,
-  getCliModelsCache,
-  CliModelsFetchError,
-  CLI_MODELS_CACHE_TTL_MS,
-} from './core/cli-models.js';
-export type { CliModelsCache } from './core/cli-models.js';
+export { CliModelsFetchError } from './core/cli-models.js';

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,3 +20,14 @@ export { detect, detectAll } from './core/detect.js';
 export { spawn } from './core/spawn.js';
 export { extract } from './core/extract.js';
 export { classifyError, classifyErrorDefault, matchSharedPatterns, parseRetryAfterMs } from './core/errors.js';
+
+export {
+  fetchCliModels,
+  ensureCliModelsCache,
+  refreshCliModelsCache,
+  clearCliModelsCache,
+  getCliModelsCache,
+  CliModelsFetchError,
+  CLI_MODELS_CACHE_TTL_MS,
+} from './core/cli-models.js';
+export type { CliModelsCache } from './core/cli-models.js';

--- a/src/models.test.ts
+++ b/src/models.test.ts
@@ -3,7 +3,7 @@ import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { CLI_PROVIDER_MAP, listModels, getKnownModels, refreshModels } from './models.js';
 import { clearCache, CACHE_TTL_MS, ModelsFetchError } from './core/models-catalog.js';
-import { clearCliModelsCache } from './core/cli-models.js';
+import { clearCliModelsCache, CliModelsFetchError } from './core/cli-models.js';
 import type { KnownModel } from './types.js';
 
 const fixtureJson = readFileSync(resolve(__dirname, '../test/fixtures/models-dev-sample.json'), 'utf8');
@@ -40,6 +40,8 @@ const defaultCliModels: KnownModel[] = [
 beforeEach(() => {
   clearCache();
   clearCliModelsCache();
+  mockEnsureCliModelsCache.mockReset();
+  mockRefreshCliModelsCache.mockReset();
   mockEnsureCliModelsCache.mockResolvedValue({ data: defaultCliModels, fetchedAt: Date.now() });
   mockRefreshCliModelsCache.mockResolvedValue({ data: defaultCliModels, fetchedAt: Date.now() });
 });
@@ -92,8 +94,42 @@ describe('listModels', () => {
 
   it('routes cli=opencode to CLI discovery (not models.dev)', async () => {
     const models = await listModels({ cli: 'opencode' });
-    expect(models.length).toBe(3); // from cliModelsFixture
+    expect(models.length).toBe(3); // from defaultCliModels
     expect(models.every(m => m.id.includes('/'))).toBe(true);
+  });
+
+  it('filters cli=opencode by provider', async () => {
+    const models = await listModels({ cli: 'opencode', provider: 'anthropic' });
+    expect(models.every(m => m.provider === 'anthropic')).toBe(true);
+    expect(models.length).toBe(2);
+  });
+
+  it('returns empty array for cli=opencode with nonexistent provider', async () => {
+    const models = await listModels({ cli: 'opencode', provider: 'nonexistent' });
+    expect(models).toHaveLength(0);
+  });
+
+  it('ignores fallback for cli=opencode and propagates error', async () => {
+    mockEnsureCliModelsCache.mockRejectedValue(new CliModelsFetchError('opencode not found', 'enoent'));
+    const fallback: KnownModel[] = [
+      { id: 'fb', name: 'FB', provider: 'anthropic', contextWindow: null, supportsEffort: false },
+    ];
+    await expect(listModels({ cli: 'opencode', fallback })).rejects.toThrow(CliModelsFetchError);
+  });
+
+  it('sorts cli=opencode results alphabetically by id', async () => {
+    const models = await listModels({ cli: 'opencode' });
+    const ids = models.map(m => m.id);
+    const sorted = [...ids].sort((a, b) => a.localeCompare(b, 'en'));
+    expect(ids).toEqual(sorted);
+  });
+
+  it('provider=anthropic without cli uses models.dev (no CLI involvement)', async () => {
+    mockFetchSuccess();
+    const models = await listModels({ provider: 'anthropic' });
+    expect(models.every(m => m.provider === 'anthropic')).toBe(true);
+    expect(models.length).toBe(2);
+    expect(mockEnsureCliModelsCache).not.toHaveBeenCalled();
   });
 
   it('filters by provider=google', async () => {
@@ -182,6 +218,12 @@ describe('getKnownModels', () => {
     const models = await getKnownModels('claude', fallback);
     expect(models).toBe(fallback);
   });
+
+  it('delegates opencode to CLI path', async () => {
+    const models = await getKnownModels('opencode');
+    expect(models.length).toBe(3);
+    expect(mockEnsureCliModelsCache).toHaveBeenCalled();
+  });
 });
 
 describe('refreshModels', () => {
@@ -192,6 +234,12 @@ describe('refreshModels', () => {
 
   it('resolves when only models.dev refresh fails (CLI succeeds)', async () => {
     mockFetchFailure();
+    await expect(refreshModels()).resolves.toBeUndefined();
+  });
+
+  it('resolves when only CLI refresh fails (models.dev succeeds)', async () => {
+    mockFetchSuccess();
+    mockRefreshCliModelsCache.mockRejectedValue(new Error('CLI failed'));
     await expect(refreshModels()).resolves.toBeUndefined();
   });
 

--- a/src/models.test.ts
+++ b/src/models.test.ts
@@ -3,10 +3,23 @@ import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { CLI_PROVIDER_MAP, listModels, getKnownModels, refreshModels } from './models.js';
 import { clearCache, CACHE_TTL_MS, ModelsFetchError } from './core/models-catalog.js';
+import { clearCliModelsCache } from './core/cli-models.js';
 import type { KnownModel } from './types.js';
 
 const fixtureJson = readFileSync(resolve(__dirname, '../test/fixtures/models-dev-sample.json'), 'utf8');
 const originalFetch = globalThis.fetch;
+
+const mockEnsureCliModelsCache = vi.fn();
+const mockRefreshCliModelsCache = vi.fn();
+
+vi.mock('./core/cli-models.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./core/cli-models.js')>();
+  return {
+    ...actual,
+    ensureCliModelsCache: (...args: unknown[]) => mockEnsureCliModelsCache(...args),
+    refreshCliModelsCache: (...args: unknown[]) => mockRefreshCliModelsCache(...args),
+  };
+});
 
 function mockFetchSuccess() {
   globalThis.fetch = vi.fn().mockImplementation(() =>
@@ -18,9 +31,17 @@ function mockFetchFailure() {
   globalThis.fetch = vi.fn().mockRejectedValue(new Error('Network error'));
 }
 
+const defaultCliModels: KnownModel[] = [
+  { id: 'anthropic/claude-sonnet-4-20250514', name: 'anthropic/claude-sonnet-4-20250514', provider: 'anthropic', contextWindow: null, supportsEffort: false },
+  { id: 'openai/gpt-4o', name: 'openai/gpt-4o', provider: 'openai', contextWindow: null, supportsEffort: false },
+  { id: 'anthropic/claude-haiku-3.5', name: 'anthropic/claude-haiku-3.5', provider: 'anthropic', contextWindow: null, supportsEffort: false },
+];
+
 beforeEach(() => {
   clearCache();
-  vi.restoreAllMocks();
+  clearCliModelsCache();
+  mockEnsureCliModelsCache.mockResolvedValue({ data: defaultCliModels, fetchedAt: Date.now() });
+  mockRefreshCliModelsCache.mockResolvedValue({ data: defaultCliModels, fetchedAt: Date.now() });
 });
 
 afterEach(() => {
@@ -28,8 +49,8 @@ afterEach(() => {
 });
 
 describe('CLI_PROVIDER_MAP', () => {
-  it('has entries for all three CliName values', () => {
-    expect(Object.keys(CLI_PROVIDER_MAP)).toEqual(['claude', 'codex', 'opencode']);
+  it('has entries for claude and codex only', () => {
+    expect(Object.keys(CLI_PROVIDER_MAP)).toEqual(['claude', 'codex']);
   });
 
   it('maps claude to anthropic', () => {
@@ -40,8 +61,8 @@ describe('CLI_PROVIDER_MAP', () => {
     expect(CLI_PROVIDER_MAP.codex).toBe('openai');
   });
 
-  it('maps opencode to null', () => {
-    expect(CLI_PROVIDER_MAP.opencode).toBeNull();
+  it('does not include opencode', () => {
+    expect('opencode' in CLI_PROVIDER_MAP).toBe(false);
   });
 });
 
@@ -69,10 +90,10 @@ describe('listModels', () => {
     expect(models.length).toBe(1);
   });
 
-  it('filters by cli=opencode → all models (no filter)', async () => {
-    mockFetchSuccess();
+  it('routes cli=opencode to CLI discovery (not models.dev)', async () => {
     const models = await listModels({ cli: 'opencode' });
-    expect(models.length).toBe(4);
+    expect(models.length).toBe(3); // from cliModelsFixture
+    expect(models.every(m => m.id.includes('/'))).toBe(true);
   });
 
   it('filters by provider=google', async () => {

--- a/src/models.test.ts
+++ b/src/models.test.ts
@@ -51,8 +51,8 @@ afterEach(() => {
 });
 
 describe('CLI_PROVIDER_MAP', () => {
-  it('has entries for claude and codex only', () => {
-    expect(Object.keys(CLI_PROVIDER_MAP)).toEqual(['claude', 'codex']);
+  it('has entries for all three CliName values', () => {
+    expect(Object.keys(CLI_PROVIDER_MAP)).toEqual(['claude', 'codex', 'opencode']);
   });
 
   it('maps claude to anthropic', () => {
@@ -63,8 +63,8 @@ describe('CLI_PROVIDER_MAP', () => {
     expect(CLI_PROVIDER_MAP.codex).toBe('openai');
   });
 
-  it('does not include opencode', () => {
-    expect('opencode' in CLI_PROVIDER_MAP).toBe(false);
+  it('maps opencode to null', () => {
+    expect(CLI_PROVIDER_MAP.opencode).toBeNull();
   });
 });
 

--- a/src/models.test.ts
+++ b/src/models.test.ts
@@ -185,23 +185,30 @@ describe('getKnownModels', () => {
 });
 
 describe('refreshModels', () => {
-  it('calls refreshCache successfully', async () => {
+  it('resolves when both caches refresh successfully', async () => {
     mockFetchSuccess();
     await expect(refreshModels()).resolves.toBeUndefined();
   });
 
-  it('throws when refreshCache fails', async () => {
+  it('resolves when only models.dev refresh fails (CLI succeeds)', async () => {
     mockFetchFailure();
-    await expect(refreshModels()).rejects.toThrow(ModelsFetchError);
+    await expect(refreshModels()).resolves.toBeUndefined();
   });
 
-  it('after failed refresh, listModels still returns cached data', async () => {
+  it('throws when both refreshes fail', async () => {
+    mockFetchFailure();
+    mockRefreshCliModelsCache.mockRejectedValue(new Error('CLI failed'));
+    await expect(refreshModels()).rejects.toThrow();
+  });
+
+  it('after failed models.dev refresh, listModels still returns cached data', async () => {
     mockFetchSuccess();
     const before = await listModels();
     expect(before.length).toBe(4);
 
     mockFetchFailure();
-    await expect(refreshModels()).rejects.toThrow();
+    // refreshModels resolves because CLI refresh succeeds
+    await expect(refreshModels()).resolves.toBeUndefined();
 
     mockFetchFailure();
     const after = await listModels();

--- a/src/models.ts
+++ b/src/models.ts
@@ -5,9 +5,10 @@ import { createDebugLogger } from './core/debug.js';
 
 const log = createDebugLogger();
 
-export const CLI_PROVIDER_MAP: Record<'claude' | 'codex', string> = {
+export const CLI_PROVIDER_MAP: Record<CliName, string | null> = {
   claude: 'anthropic',
   codex: 'openai',
+  opencode: null,
 };
 
 export async function listModels(options?: ListModelsOptions): Promise<KnownModel[]> {
@@ -44,7 +45,7 @@ export async function listModels(options?: ListModelsOptions): Promise<KnownMode
     providerFilter = options.provider;
     log?.(`listModels: filtering by provider=${providerFilter}`);
   } else if (options?.cli) {
-    providerFilter = CLI_PROVIDER_MAP[options.cli as keyof typeof CLI_PROVIDER_MAP];
+    providerFilter = CLI_PROVIDER_MAP[options.cli];
     log?.(`listModels: filtering by cli=${options.cli} → provider=${providerFilter}`);
   }
 
@@ -78,6 +79,9 @@ export async function refreshModels(): Promise<void> {
   ]);
 
   const failures = results.filter((r): r is PromiseRejectedResult => r.status === 'rejected');
+  for (const f of failures) {
+    log?.(`refreshModels: partial failure: ${f.reason}`);
+  }
   if (failures.length === results.length) {
     throw failures[0].reason;
   }

--- a/src/models.ts
+++ b/src/models.ts
@@ -1,6 +1,6 @@
 import type { CliName, KnownModel, ListModelsOptions } from './types.js';
 import { ensureCache, refreshCache } from './core/models-catalog.js';
-import { ensureCliModelsCache } from './core/cli-models.js';
+import { ensureCliModelsCache, refreshCliModelsCache } from './core/cli-models.js';
 import { createDebugLogger } from './core/debug.js';
 
 const log = createDebugLogger();
@@ -71,7 +71,15 @@ export async function getKnownModels(cli?: CliName, fallbackModels?: KnownModel[
 }
 
 export async function refreshModels(): Promise<void> {
-  log?.('refreshModels: refreshing cache');
-  await refreshCache();
-  log?.('refreshModels: cache refreshed');
+  log?.('refreshModels: refreshing both caches');
+  const results = await Promise.allSettled([
+    refreshCache(),
+    refreshCliModelsCache(),
+  ]);
+
+  const failures = results.filter((r): r is PromiseRejectedResult => r.status === 'rejected');
+  if (failures.length === results.length) {
+    throw failures[0].reason;
+  }
+  log?.('refreshModels: caches refreshed');
 }

--- a/src/models.ts
+++ b/src/models.ts
@@ -1,16 +1,33 @@
 import type { CliName, KnownModel, ListModelsOptions } from './types.js';
 import { ensureCache, refreshCache } from './core/models-catalog.js';
+import { ensureCliModelsCache } from './core/cli-models.js';
 import { createDebugLogger } from './core/debug.js';
 
 const log = createDebugLogger();
 
-export const CLI_PROVIDER_MAP: Record<CliName, string | null> = {
+export const CLI_PROVIDER_MAP: Record<'claude' | 'codex', string> = {
   claude: 'anthropic',
   codex: 'openai',
-  opencode: null,
 };
 
 export async function listModels(options?: ListModelsOptions): Promise<KnownModel[]> {
+  // OpenCode: use CLI-based model discovery
+  if (options?.cli === 'opencode') {
+    log?.('listModels: using CLI discovery for opencode');
+    const cliCache = await ensureCliModelsCache();
+    let models = [...cliCache.data];
+
+    if (options.provider) {
+      log?.(`listModels: filtering CLI models by provider=${options.provider}`);
+      models = models.filter(m => m.provider === options.provider);
+    }
+
+    models.sort((a, b) => a.id.localeCompare(b.id, 'en'));
+    log?.(`listModels: returning ${models.length} CLI models`);
+    return models;
+  }
+
+  // Claude, Codex, or no CLI: use models.dev
   let cache;
   try {
     cache = await ensureCache();
@@ -27,7 +44,7 @@ export async function listModels(options?: ListModelsOptions): Promise<KnownMode
     providerFilter = options.provider;
     log?.(`listModels: filtering by provider=${providerFilter}`);
   } else if (options?.cli) {
-    providerFilter = CLI_PROVIDER_MAP[options.cli];
+    providerFilter = CLI_PROVIDER_MAP[options.cli as keyof typeof CLI_PROVIDER_MAP];
     log?.(`listModels: filtering by cli=${options.cli} → provider=${providerFilter}`);
   }
 

--- a/test/core/cli-models.test.ts
+++ b/test/core/cli-models.test.ts
@@ -106,12 +106,12 @@ describe('parseCliModelsOutput', () => {
     expect(models).toHaveLength(2);
   });
 
-  it('uses full line as id, name, and provider when no / separator', () => {
+  it('uses "unknown" as provider when no / separator', () => {
     const models = parseCliModelsOutput('some-model-without-slash');
     expect(models[0]).toEqual({
       id: 'some-model-without-slash',
       name: 'some-model-without-slash',
-      provider: 'some-model-without-slash',
+      provider: 'unknown',
       contextWindow: null,
       supportsEffort: false,
     });
@@ -284,6 +284,28 @@ describe('cache', () => {
 
     // Cache unchanged
     expect(getCliModelsCache()).toBe(cached);
+  });
+
+  it('returns stale cache when fetch fails after TTL expiry', async () => {
+    mockQueue.push(createMockProcess({
+      stdoutLines: ['anthropic/claude-sonnet-4-20250514'],
+      exitCode: 0,
+    }));
+
+    await ensureCliModelsCache();
+    const cached = getCliModelsCache()!;
+    cached.fetchedAt = Date.now() - CLI_MODELS_CACHE_TTL_MS - 1;
+
+    mockQueue.push(createEnoentProcess());
+
+    const result = await ensureCliModelsCache();
+    expect(result.data).toHaveLength(1);
+    expect(result.data[0].id).toBe('anthropic/claude-sonnet-4-20250514');
+  });
+
+  it('throws when fetch fails with no prior cache', async () => {
+    mockQueue.push(createEnoentProcess());
+    await expect(ensureCliModelsCache()).rejects.toThrow(CliModelsFetchError);
   });
 
   it('clearCliModelsCache invalidates cache', async () => {

--- a/test/core/cli-models.test.ts
+++ b/test/core/cli-models.test.ts
@@ -1,0 +1,300 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { EventEmitter } from 'node:events';
+import { PassThrough } from 'node:stream';
+import { createMockProcess, type MockChildProcess } from '../helpers/mock-process.js';
+
+const mockQueue: MockChildProcess[] = [];
+
+vi.mock('node:child_process', () => ({
+  spawn: vi.fn(() => {
+    const proc = mockQueue.shift();
+    if (!proc) throw new Error('mockQueue is empty — test is missing a mock process');
+    return proc;
+  }),
+}));
+
+// Import after mock registration
+const {
+  parseCliModelsOutput,
+  fetchCliModels,
+  ensureCliModelsCache,
+  refreshCliModelsCache,
+  clearCliModelsCache,
+  getCliModelsCache,
+  CliModelsFetchError,
+  CLI_MODELS_CACHE_TTL_MS,
+} = await import('../../src/core/cli-models.js');
+
+function createEnoentProcess(): MockChildProcess {
+  const proc = new EventEmitter() as MockChildProcess;
+  proc.stdout = new PassThrough();
+  proc.stderr = new PassThrough();
+  proc.stdin = new PassThrough();
+  proc.pid = 88888;
+  proc.killed = false;
+  proc.kill = () => { proc.killed = true; return true; };
+
+  setImmediate(() => {
+    const err = new Error('spawn opencode ENOENT') as NodeJS.ErrnoException;
+    err.code = 'ENOENT';
+    proc.stdout.end();
+    proc.stderr.end();
+    proc.emit('error', err);
+  });
+
+  return proc;
+}
+
+function createErrorProcess(error: Error): MockChildProcess {
+  const proc = new EventEmitter() as MockChildProcess;
+  proc.stdout = new PassThrough();
+  proc.stderr = new PassThrough();
+  proc.stdin = new PassThrough();
+  proc.pid = 88889;
+  proc.killed = false;
+  proc.kill = () => { proc.killed = true; return true; };
+
+  setImmediate(() => {
+    proc.stdout.end();
+    proc.stderr.end();
+    proc.emit('error', error);
+  });
+
+  return proc;
+}
+
+function createHangingProcess(): MockChildProcess {
+  const proc = new EventEmitter() as MockChildProcess;
+  proc.stdout = new PassThrough();
+  proc.stderr = new PassThrough();
+  proc.stdin = new PassThrough();
+  proc.pid = 77777;
+  proc.killed = false;
+  proc.kill = (signal?: string) => {
+    if (proc.killed) return false;
+    proc.killed = true;
+    proc.emit('close', signal === 'SIGKILL' ? 137 : 143, signal ?? 'SIGTERM');
+    return true;
+  };
+
+  return proc;
+}
+
+describe('parseCliModelsOutput', () => {
+  it('parses valid multi-line stdout into KnownModel[]', () => {
+    const stdout = [
+      'anthropic/claude-sonnet-4-20250514',
+      'openai/gpt-4o',
+      'google/gemini-2.0-flash',
+    ].join('\n');
+
+    const models = parseCliModelsOutput(stdout);
+    expect(models).toEqual([
+      { id: 'anthropic/claude-sonnet-4-20250514', name: 'anthropic/claude-sonnet-4-20250514', provider: 'anthropic', contextWindow: null, supportsEffort: false },
+      { id: 'openai/gpt-4o', name: 'openai/gpt-4o', provider: 'openai', contextWindow: null, supportsEffort: false },
+      { id: 'google/gemini-2.0-flash', name: 'google/gemini-2.0-flash', provider: 'google', contextWindow: null, supportsEffort: false },
+    ]);
+  });
+
+  it('returns empty array for empty stdout', () => {
+    expect(parseCliModelsOutput('')).toEqual([]);
+  });
+
+  it('filters blank lines and trailing newlines', () => {
+    const stdout = 'anthropic/claude-sonnet-4-20250514\n\n\nopenai/gpt-4o\n\n';
+    const models = parseCliModelsOutput(stdout);
+    expect(models).toHaveLength(2);
+  });
+
+  it('uses full line as id, name, and provider when no / separator', () => {
+    const models = parseCliModelsOutput('some-model-without-slash');
+    expect(models[0]).toEqual({
+      id: 'some-model-without-slash',
+      name: 'some-model-without-slash',
+      provider: 'some-model-without-slash',
+      contextWindow: null,
+      supportsEffort: false,
+    });
+  });
+});
+
+describe('fetchCliModels', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockQueue.length = 0;
+    clearCliModelsCache();
+  });
+
+  it('returns parsed models on success', async () => {
+    mockQueue.push(createMockProcess({
+      stdoutLines: ['anthropic/claude-sonnet-4-20250514', 'openai/gpt-4o'],
+      exitCode: 0,
+    }));
+
+    const models = await fetchCliModels();
+    expect(models).toHaveLength(2);
+    expect(models[0].provider).toBe('anthropic');
+    expect(models[1].provider).toBe('openai');
+  });
+
+  it('throws CliModelsFetchError with kind enoent when binary not found', async () => {
+    mockQueue.push(createEnoentProcess());
+
+    const err = await fetchCliModels().catch((e: InstanceType<typeof CliModelsFetchError>) => e);
+    expect(err).toBeInstanceOf(CliModelsFetchError);
+    expect(err.kind).toBe('enoent');
+  });
+
+  it('throws CliModelsFetchError with kind timeout', async () => {
+    mockQueue.push(createHangingProcess());
+
+    const err = await fetchCliModels().catch((e: InstanceType<typeof CliModelsFetchError>) => e);
+    expect(err).toBeInstanceOf(CliModelsFetchError);
+    expect(err.kind).toBe('timeout');
+  }, 15_000);
+
+  it('throws CliModelsFetchError with kind error and cause on generic spawn error', async () => {
+    const cause = new Error('something went wrong');
+    mockQueue.push(createErrorProcess(cause));
+
+    const err = await fetchCliModels().catch((e: InstanceType<typeof CliModelsFetchError>) => e);
+    expect(err).toBeInstanceOf(CliModelsFetchError);
+    expect(err.kind).toBe('error');
+    expect(err.cause).toBeInstanceOf(Error);
+  });
+
+  it('throws CliModelsFetchError with kind exit_code and stderr in message', async () => {
+    mockQueue.push(createMockProcess({
+      stdoutLines: [],
+      stderrLines: ['Error: no providers configured'],
+      exitCode: 1,
+    }));
+
+    const err = await fetchCliModels().catch((e: InstanceType<typeof CliModelsFetchError>) => e);
+    expect(err).toBeInstanceOf(CliModelsFetchError);
+    expect(err.kind).toBe('exit_code');
+    expect(err.message).toContain('no providers configured');
+  });
+});
+
+describe('cache', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockQueue.length = 0;
+    clearCliModelsCache();
+  });
+
+  it('getCliModelsCache returns null initially', () => {
+    expect(getCliModelsCache()).toBeNull();
+  });
+
+  it('ensureCliModelsCache fetches and caches on first call', async () => {
+    mockQueue.push(createMockProcess({
+      stdoutLines: ['anthropic/claude-sonnet-4-20250514'],
+      exitCode: 0,
+    }));
+
+    const result = await ensureCliModelsCache();
+    expect(result.data).toHaveLength(1);
+    expect(result.fetchedAt).toBeGreaterThan(0);
+    expect(getCliModelsCache()).toBe(result);
+  });
+
+  it('returns cached data without spawning on second call within TTL', async () => {
+    const { spawn } = await import('node:child_process');
+
+    mockQueue.push(createMockProcess({
+      stdoutLines: ['anthropic/claude-sonnet-4-20250514'],
+      exitCode: 0,
+    }));
+
+    await ensureCliModelsCache();
+    const callCount = vi.mocked(spawn).mock.calls.length;
+
+    const result2 = await ensureCliModelsCache();
+    expect(result2.data).toHaveLength(1);
+    expect(vi.mocked(spawn).mock.calls.length).toBe(callCount); // no new spawn
+  });
+
+  it('re-fetches when cache TTL expires', async () => {
+    mockQueue.push(createMockProcess({
+      stdoutLines: ['anthropic/claude-sonnet-4-20250514'],
+      exitCode: 0,
+    }));
+
+    await ensureCliModelsCache();
+
+    // Simulate TTL expiry by backdating fetchedAt
+    const cached = getCliModelsCache()!;
+    cached.fetchedAt = Date.now() - CLI_MODELS_CACHE_TTL_MS - 1;
+
+    mockQueue.push(createMockProcess({
+      stdoutLines: ['anthropic/claude-sonnet-4-20250514', 'openai/gpt-4o'],
+      exitCode: 0,
+    }));
+
+    const result = await ensureCliModelsCache();
+    expect(result.data).toHaveLength(2);
+  });
+
+  it('deduplicates concurrent calls — only one subprocess', async () => {
+    const { spawn } = await import('node:child_process');
+
+    mockQueue.push(createMockProcess({
+      stdoutLines: ['anthropic/claude-sonnet-4-20250514'],
+      exitCode: 0,
+    }));
+
+    const p1 = ensureCliModelsCache();
+    const p2 = ensureCliModelsCache();
+
+    const [r1, r2] = await Promise.all([p1, p2]);
+    expect(r1).toBe(r2);
+    expect(vi.mocked(spawn).mock.calls.length).toBe(1);
+  });
+
+  it('refreshCliModelsCache always fetches even with fresh cache', async () => {
+    const { spawn } = await import('node:child_process');
+
+    mockQueue.push(createMockProcess({
+      stdoutLines: ['anthropic/claude-sonnet-4-20250514'],
+      exitCode: 0,
+    }));
+    await ensureCliModelsCache();
+
+    mockQueue.push(createMockProcess({
+      stdoutLines: ['anthropic/claude-sonnet-4-20250514', 'openai/gpt-4o'],
+      exitCode: 0,
+    }));
+    const result = await refreshCliModelsCache();
+    expect(result.data).toHaveLength(2);
+    expect(vi.mocked(spawn).mock.calls.length).toBe(2);
+  });
+
+  it('refreshCliModelsCache throws on failure without updating cache', async () => {
+    mockQueue.push(createMockProcess({
+      stdoutLines: ['anthropic/claude-sonnet-4-20250514'],
+      exitCode: 0,
+    }));
+    await ensureCliModelsCache();
+    const cached = getCliModelsCache();
+
+    mockQueue.push(createEnoentProcess());
+    await expect(refreshCliModelsCache()).rejects.toThrow(CliModelsFetchError);
+
+    // Cache unchanged
+    expect(getCliModelsCache()).toBe(cached);
+  });
+
+  it('clearCliModelsCache invalidates cache', async () => {
+    mockQueue.push(createMockProcess({
+      stdoutLines: ['anthropic/claude-sonnet-4-20250514'],
+      exitCode: 0,
+    }));
+    await ensureCliModelsCache();
+    expect(getCliModelsCache()).not.toBeNull();
+
+    clearCliModelsCache();
+    expect(getCliModelsCache()).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
Multi-spec build session covering: 12-opencode-cli-model-discovery, 13-opencode-models-integration

### Completed Specs
- **specs/12-opencode-cli-model-discovery.md** — New `src/core/cli-models.ts` module: executes `opencode models` CLI, parses output to `KnownModel[]`, caches with 24h TTL, concurrent deduplication
- **specs/13-opencode-models-integration.md** — Wires CLI discovery into `listModels`/`refreshModels` public API: opencode routes to CLI, claude/codex unchanged, `refreshModels` refreshes both caches via `Promise.allSettled`

### Completed Tasks
- spawner-4ty: Add CliModelsFetchError class and parseCliModelsOutput function
- spawner-fpb: Implement fetchCliModels function
- spawner-g20: Implement cache layer with ensureCliModelsCache and helpers
- spawner-8qt: Add unit tests for parsing and error handling
- spawner-ld7: Add unit tests for cache TTL, deduplication, refresh, and clear
- spawner-j4f: Export cli-models public API from index.ts
- spawner-vz1: Branch listModels for opencode CLI path and narrow CLI_PROVIDER_MAP
- spawner-stp: Update refreshModels to refresh both caches with Promise.allSettled
- spawner-6eu: Update models.test.ts for opencode CLI routing and refreshModels changes

### Testing
- `pnpm build && pnpm lint` passing
- `pnpm test` — 303 tests passing across 16 test files
- Tested: CLI model parsing, error handling (ENOENT, timeout, exit code), cache TTL/dedup/refresh, listModels routing for opencode/claude/codex, provider filtering, fallback behavior, refreshModels parallel semantics