### PR TITLE
fix(codex): map autoApprove to full bypass for parity with claude

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ Spawns a CLI process and returns a handle for streaming events and awaiting the 
 | `model` | `string` | CLI default | Model identifier to use |
 | `sessionId` | `string` | -- | Resume an existing session |
 | `effort` | `'low' \| 'medium' \| 'high' \| 'max'` | -- | Effort level (supported by some models) |
-| `autoApprove` | `boolean` | -- | Skip tool confirmation prompts |
+| `autoApprove` | `boolean` | -- | Skip tool confirmation prompts. Maps to full permission/sandbox bypass on claude (`--dangerously-skip-permissions`) and codex (`--dangerously-bypass-approvals-and-sandbox`). No effect on opencode. |
 | `forkSession` | `boolean` | -- | Fork from an existing session |
 | `continueSession` | `boolean` | -- | Continue the most recent session |
 | `addDirs` | `string[]` | -- | Additional directories to include |

--- a/specs/03-command-building.md
+++ b/specs/03-command-building.md
@@ -88,7 +88,7 @@ The base command depends on session state:
 | SpawnOption | Flag | Notes |
 |-------------|------|-------|
 | `model` | `--model <model>` | |
-| `autoApprove` | `--full-auto` | For unrestricted: use `extraArgs: ['--yolo']` |
+| `autoApprove` | `--dangerously-bypass-approvals-and-sandbox` | Full bypass (matches claude's `--dangerously-skip-permissions`). For sandboxed auto-approve: use `extraArgs: ['--full-auto']` |
 | `addDirs` | `--add-dir <dir>` (repeated) | |
 | `ephemeral` | `--ephemeral` | |
 | `effort` | `-c model_reasoning_effort=<effort>` | Config flag syntax |

--- a/src/adapters/codex.ts
+++ b/src/adapters/codex.ts
@@ -53,7 +53,7 @@ export const codexAdapter: CliAdapter = {
     }
 
     if (options.autoApprove) {
-      args.push('--full-auto');
+      args.push('--dangerously-bypass-approvals-and-sandbox');
     }
 
     if (options.addDirs) {


### PR DESCRIPTION
## Summary
- Implements **Option A** from #12: codex's `autoApprove: true` now maps to `--dangerously-bypass-approvals-and-sandbox` instead of `--full-auto`, giving consistent "full bypass" semantics across claude and codex.
- Callers who still want sandboxed auto-approve can opt in explicitly via `extraArgs: ['--full-auto']`.
- Updates README and spec flag-mapping table to document the new behavior.

## Breaking change
Behavioral only (type signature unchanged). Users relying on codex's previous sandboxed behavior via `autoApprove: true` must now pass `extraArgs: ['--full-auto']` to preserve it.

Fixes #12

## Test plan
- [x] `pnpm test` — 610 tests pass
- [ ] Manual smoke: codex with `autoApprove: true` writes files outside prior sandbox constraints