### PR TITLE
ci: pin release workflow node to 22.14.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 22.14.0
           cache: pnpm
 
       - name: Upgrade npm for OIDC trusted publishing


### PR DESCRIPTION
## Summary
- Node 22 on ubuntu-latest now resolves to 22.22.2, which ships a broken npm that fails `npm install -g npm@latest` with `MODULE_NOT_FOUND: promise-retry`. That failed the Release workflow on the last main push ([run](https://github.com/0xtiby/spawner/actions/runs/24533354556/job/71722066639)).
- Pin to 22.14.0 (the version `0xtiby/toby` uses successfully on the same workflow shape).

## Test plan
- [ ] Merge and confirm Release workflow completes through `semantic-release`