### PR TITLE
feat: add pi (coding agent) support

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 ## What Is Spawner?
 
-A single async iterable API to drive **Claude Code**, **Codex CLI**, and **OpenCode** programmatically:
+A single async iterable API to drive **Claude Code**, **Codex CLI**, **OpenCode**, and **pi** programmatically:
 
 1. You pass `SpawnOptions` to `spawn()`.
 2. You iterate typed `CliEvent` objects as they stream in (text, tool use, tool result, errors).
@@ -71,25 +71,32 @@ pnpm add @0xtiby/spawner
 - [Claude Code](https://docs.anthropic.com/en/docs/claude-code) (`claude`)
 - [Codex CLI](https://github.com/openai/codex) (`codex`)
 - [OpenCode](https://github.com/sst/opencode) (`opencode`)
+- [pi](https://github.com/badlogic/pi-mono) (`pi`)
 
 ## CLI Feature Parity
 
 Not every CLI supports every `SpawnOptions` field. This table shows what each adapter passes through and what it silently ignores.
 
-| Feature | Claude | Codex | OpenCode |
-|---|---|---|---|
-| `model` | Yes | Yes | Yes |
-| `sessionId` | Yes | Yes | Yes |
-| `continueSession` | Yes | Yes | Yes |
-| `forkSession` | Yes | Yes | Yes |
-| `autoApprove` | Yes | Yes | -- |
-| `effort` | Yes | Yes | -- |
-| `addDirs` | Yes | Yes | -- |
-| `ephemeral` | Yes | Yes | -- |
-| `allowInteractiveTools` | Yes | -- | -- |
-| `extraArgs` | Yes | Yes | Yes |
+| Feature | Claude | Codex | OpenCode | pi |
+|---|---|---|---|---|
+| `model` | Yes | Yes | Yes | Yes |
+| `sessionId` | Yes | Yes | Yes | Yes |
+| `continueSession` | Yes | Yes | Yes | Yes |
+| `forkSession` | Yes | Yes | Yes | Yes |
+| `autoApprove` | Yes | Yes | -- | No-op |
+| `effort` | Yes | Yes | -- | Yes |
+| `addDirs` | Yes | Yes | -- | -- |
+| `ephemeral` | Yes | Yes | -- | Yes |
+| `allowInteractiveTools` | Yes | -- | -- | -- |
+| `extraArgs` | Yes | Yes | Yes | Yes |
 
-**Legend:** "Yes" = passed to the CLI. "--" = silently ignored.
+**Legend:** "Yes" = passed to the CLI. "--" = silently ignored. "No-op" = accepted but has no effect (the CLI is already non-interactive).
+
+### Pi-specific notes
+
+- `autoApprove` is a no-op: `pi --mode json` is already a headless print mode with no approval prompts.
+- `addDirs` and `allowInteractiveTools` are silently ignored so existing `SpawnOptions` work without crashing.
+- `effort` is mapped to `--thinking <level>`. `off` and `minimal` are dropped (pi has no equivalent); `max`/`xhigh` map to `xhigh`.
 
 ## Core Concepts
 
@@ -272,12 +279,12 @@ Spawns a CLI process and returns a handle for streaming events and awaiting the 
 
 | Option | Type | Default | Description |
 |---|---|---|---|
-| `cli` | `CliName` | *required* | Which CLI to spawn: `'claude'`, `'codex'`, or `'opencode'` |
+| `cli` | `CliName` | *required* | Which CLI to spawn: `'claude'`, `'codex'`, `'opencode'`, or `'pi'` |
 | `prompt` | `string` | *required* | The prompt to send to the CLI |
 | `cwd` | `string` | *required* | Working directory for the process |
 | `model` | `string` | CLI default | Model identifier to use |
 | `sessionId` | `string` | -- | Resume an existing session |
-| `effort` | `'low' \| 'medium' \| 'high' \| 'max'` | -- | Effort level (supported by some models) |
+| `effort` | `'off' \| 'minimal' \| 'low' \| 'medium' \| 'high' \| 'max' \| 'xhigh'` | -- | Effort/reasoning level (supported by some models) |
 | `autoApprove` | `boolean` | -- | Skip tool confirmation prompts. Maps to full permission/sandbox bypass on claude (`--dangerously-skip-permissions`) and codex (`--dangerously-bypass-approvals-and-sandbox`). No effect on opencode. |
 | `forkSession` | `boolean` | -- | Fork from an existing session |
 | `continueSession` | `boolean` | -- | Continue the most recent session |
@@ -335,7 +342,7 @@ Checks whether a CLI is installed, its version, and authentication status.
 
 ### `detectAll(): Promise<Record<CliName, DetectResult>>`
 
-Runs `detect()` for all three CLIs concurrently.
+Runs `detect()` for all four CLIs concurrently.
 
 ### `extract(options: ExtractOptions): CliResult`
 

--- a/README.md
+++ b/README.md
@@ -96,7 +96,8 @@ Not every CLI supports every `SpawnOptions` field. This table shows what each ad
 
 - `autoApprove` is a no-op: `pi --mode json` is already a headless print mode with no approval prompts.
 - `addDirs` and `allowInteractiveTools` are silently ignored so existing `SpawnOptions` work without crashing.
-- `effort` is mapped to `--thinking <level>`. `off` and `minimal` are dropped (pi has no equivalent); `max`/`xhigh` map to `xhigh`.
+- `effort` is mapped to `--thinking <level>`. Pi accepts `off`, `minimal`, `low`, `medium`, `high`, `xhigh` natively, so all values pass through; `max` collapses to `xhigh`.
+- `detect()` reports `authenticated: true` whenever the `pi` binary exists. Pi resolves credentials per provider at runtime (env vars, config file), so this signal is non-authoritative — real auth failures surface via `classifyError` when you actually spawn.
 
 ## Core Concepts
 

--- a/specs/14-pi-adapter.md
+++ b/specs/14-pi-adapter.md
@@ -1,0 +1,141 @@
+---
+title: "Spec: Pi Adapter"
+created: 2026-04-27
+updated: 2026-04-27
+tags: [spawner, spec, adapter, pi]
+---
+
+# Pi Adapter
+
+## Overview
+
+Add a `pi` adapter that drives the [pi-mono](https://github.com/badlogic/pi-mono) coding agent in headless mode via `pi --mode json`. Pi emits a JSONL event stream of `AgentSessionEvent` objects which the adapter parses into normalized `CliEvent` objects.
+
+**Source:** `src/adapters/pi.ts`.
+
+## Scope
+
+**In:** Adapter implementation (`detect`, `buildCommand`, `parseLine`, `classifyError`), JSONL event parsing, error classification, integration with the shared effort-mapping module.
+
+**Out:** Interactive TUI mode, real-time auth validation, parsing `pi --list-models` output (spawner uses models.dev), pi-specific options outside `SpawnOptions` (users can pass via `extraArgs`).
+
+---
+
+## Public Behavior
+
+### `detect()`
+
+- Runs `pi --version` to derive the version string and binary presence.
+- `installed: false` when the binary is missing (`ENOENT`).
+- `authenticated: true` is reported optimistically because pi's auth is provider-specific and runtime-determined; real auth failures surface via `classifyError` at runtime.
+
+### `buildCommand(options)`
+
+Always emits `pi --mode json` plus translated flags. The prompt is appended as the final positional argument so that `extraArgs` are parsed as flags before it.
+
+| `SpawnOptions` field | Pi flag | Notes |
+|---|---|---|
+| `model` | `--model <id>` | Direct passthrough |
+| `sessionId` | `--session <id>` | Resume an existing session |
+| `continueSession` | `--continue` | Used only when `sessionId` is unset |
+| `forkSession` + `sessionId` | `--fork <id>` | Strips `--session`/`--continue` first |
+| `ephemeral` | `--no-session` | Run without persisting session |
+| `verbose` | `--verbose` | Debug logging to stderr |
+| `effort` | `--thinking <level>` | Via `mapEffortToCliFlag('pi', effort)` |
+| `extraArgs` | passthrough | Inserted before the positional prompt |
+| `prompt` | positional | Appended last |
+| `autoApprove` | -- | No-op (`--mode json` is non-interactive) |
+| `addDirs` | -- | Silently ignored |
+| `allowInteractiveTools` | -- | Silently ignored |
+
+### `parseLine(line, accumulator)`
+
+Each non-empty line is parsed as JSON; malformed lines fall through to a single `system` event preserving the raw line.
+
+### `classifyError(exitCode, stderr, stdout)`
+
+Pattern-matches stderr/stdout against pi-specific regexes; otherwise delegates to `classifyErrorDefault`.
+
+---
+
+## Event Type Mapping
+
+| Pi event `type` | Spawner `CliEvent` | Notes |
+|---|---|---|
+| `session` | `system` | Captures `id` → `accumulator.sessionId`, `model` → `accumulator.model` |
+| `agent_start` | `system` | Lifecycle marker |
+| `turn_start` | `system` | Lifecycle marker |
+| `message_start` (assistant) | -- | No event; updates `accumulator.model` |
+| `message_update` → `text_end` | `text` | `content` from the assistant event |
+| `message_update` → `toolcall_end` | `tool_use` | `tool.name`, `tool.input` from `toolCall` |
+| `message_update` → `error` | `error` | `errorMessage` from the assistant event |
+| `message_update` → `thinking_*` | -- | Skipped (matches Claude/Codex behavior) |
+| `message_end` (assistant) | -- or `error` | Updates token usage; emits `error` when `stopReason` is `error`/`aborted` |
+| `tool_execution_start` | -- | Skipped |
+| `tool_execution_update` | -- | Skipped |
+| `tool_execution_end` | `tool_result` | `toolResult.name`, `output`, `error` if `isError` |
+| `turn_end` | `system` (or `error`) | Updates token usage; emits `error` on `stopReason: error|aborted` |
+| `agent_end` | `system` | Lifecycle marker |
+| *unknown* | `system` | Fallback preserves the raw line |
+
+---
+
+## Session Management
+
+| Goal | Flags emitted |
+|---|---|
+| New session (default) | none |
+| Resume by ID | `--session <id>` |
+| Resume most recent | `--continue` |
+| Fork from a known session | `--fork <id>` (strips `--session`/`--continue`) |
+| Run ephemerally | `--no-session` |
+
+`forkSession` only takes effect when `sessionId` is set; `--fork` requires an explicit identifier.
+
+---
+
+## Effort Mapping
+
+`SpawnOptions.effort` (the unified `EffortLevel`) is translated by the centralized `mapEffortToCliFlag('pi', effort)` helper.
+
+| `EffortLevel` | Pi flag |
+|---|---|
+| `off` | -- (dropped) |
+| `minimal` | -- (dropped) |
+| `low` | `--thinking low` |
+| `medium` | `--thinking medium` |
+| `high` | `--thinking high` |
+| `max` | `--thinking xhigh` |
+| `xhigh` | `--thinking xhigh` |
+
+---
+
+## Error Classification
+
+Pi-specific patterns checked in this order; first match wins. A non-match falls through to `classifyErrorDefault`.
+
+| `CliErrorCode` | Regex (case-insensitive) | Retryable |
+|---|---|---|
+| `model_not_found` | `model.*not found`, `not found.*model`, `unknown model` | `false` |
+| `auth` | `api key`, `unauthorized`, `authentication` | `false` |
+| `rate_limit` | `rate limit`, `too many requests`, `ratelimit` | `true` |
+| `context_overflow` | `context.*length`, `too long`, `token limit`, `maximum context`, `context window` | `false` |
+
+The `matchedLine` is the first stderr/stdout line that triggered the regex, trimmed.
+
+---
+
+## Testing Approach
+
+- **Fixture-based replay** (`test/adapters/pi.test.ts`): real JSONL captured from `pi --mode json` is fed to `parseLine` and the emitted `CliEvent` sequence is asserted line-by-line. Coverage:
+  - Text response parsing (`text_end`)
+  - Tool call → `tool_use`
+  - Tool execution → `tool_result`
+  - Session header capture (sessionId + model on accumulator)
+  - Token usage accumulation from `message_end` and `turn_end`
+  - Error path: `stopReason: error` emits a `CliEvent` of type `error`
+- **`buildCommand` tests**: assert flag composition for every `SpawnOptions` field combination, including `forkSession` precedence over `--session`/`--continue`.
+- **`classifyError` tests**: each regex row exercised with a representative stderr/stdout line.
+- **Effort mapping tests**: parametrized `(cli, effort) → flag` table including `off`/`minimal` drop and `max`/`xhigh` collapse.
+- **Adapter registry test** (`src/adapters/index.test.ts`): `getAdapter('pi')` returns the pi adapter with all required methods.
+- **E2E** (`test/e2e.test.ts`): `pi` is included in `CLI_NAMES`; spawn/listModels/session-continuity tests run when pi is installed and authenticated, otherwise skipped.

--- a/specs/14-pi-adapter.md
+++ b/specs/14-pi-adapter.md
@@ -90,7 +90,7 @@ Pattern-matches stderr/stdout against pi-specific regexes; otherwise delegates t
 | Fork from a known session | `--fork <id>` (strips `--session`/`--continue`) |
 | Run ephemerally | `--no-session` |
 
-`forkSession` only takes effect when `sessionId` is set; `--fork` requires an explicit identifier.
+`forkSession` only takes effect when `sessionId` is set; `--fork` requires an explicit identifier. Calling `forkSession: true` without a `sessionId` is a no-op (no `--fork` argument is emitted).
 
 ---
 
@@ -100,8 +100,8 @@ Pattern-matches stderr/stdout against pi-specific regexes; otherwise delegates t
 
 | `EffortLevel` | Pi flag |
 |---|---|
-| `off` | -- (dropped) |
-| `minimal` | -- (dropped) |
+| `off` | `--thinking off` |
+| `minimal` | `--thinking minimal` |
 | `low` | `--thinking low` |
 | `medium` | `--thinking medium` |
 | `high` | `--thinking high` |
@@ -136,6 +136,6 @@ The `matchedLine` is the first stderr/stdout line that triggered the regex, trim
   - Error path: `stopReason: error` emits a `CliEvent` of type `error`
 - **`buildCommand` tests**: assert flag composition for every `SpawnOptions` field combination, including `forkSession` precedence over `--session`/`--continue`.
 - **`classifyError` tests**: each regex row exercised with a representative stderr/stdout line.
-- **Effort mapping tests**: parametrized `(cli, effort) → flag` table including `off`/`minimal` drop and `max`/`xhigh` collapse.
+- **Effort mapping tests**: parametrized `(cli, effort) → flag` table including `off`/`minimal` drop (claude/codex) vs pass-through (pi) and `max`/`xhigh` collapse.
 - **Adapter registry test** (`src/adapters/index.test.ts`): `getAdapter('pi')` returns the pi adapter with all required methods.
 - **E2E** (`test/e2e.test.ts`): `pi` is included in `CLI_NAMES`; spawn/listModels/session-continuity tests run when pi is installed and authenticated, otherwise skipped.

--- a/src/adapters/claude.ts
+++ b/src/adapters/claude.ts
@@ -3,6 +3,7 @@ import type { CliAdapter, SessionAccumulator } from './types.js';
 import { execCommand } from '../core/detect.js';
 import type { ExecResult } from '../core/detect.js';
 import { matchSharedPatterns, parseRetryAfterMs, classifyErrorDefault } from '../core/errors.js';
+import { mapEffortToCliFlag } from '../core/effort.js';
 
 function isExecResult(result: Awaited<ReturnType<typeof execCommand>>): result is ExecResult {
   return 'exitCode' in result;
@@ -54,7 +55,8 @@ export const claudeAdapter: CliAdapter = {
     }
 
     if (options.effort) {
-      args.push('--effort', options.effort);
+      const mapped = mapEffortToCliFlag('claude', options.effort);
+      if (mapped) args.push(mapped.flag, mapped.value);
     }
 
     if (options.autoApprove) {

--- a/src/adapters/codex.ts
+++ b/src/adapters/codex.ts
@@ -3,6 +3,7 @@ import type { CliAdapter, SessionAccumulator } from './types.js';
 import { execCommand } from '../core/detect.js';
 import type { ExecResult } from '../core/detect.js';
 import { classifyErrorDefault } from '../core/errors.js';
+import { mapEffortToCliFlag } from '../core/effort.js';
 
 function isExecResult(result: Awaited<ReturnType<typeof execCommand>>): result is ExecResult {
   return 'exitCode' in result;
@@ -67,7 +68,8 @@ export const codexAdapter: CliAdapter = {
     }
 
     if (options.effort) {
-      args.push('-c', `model_reasoning_effort=${options.effort}`);
+      const mapped = mapEffortToCliFlag('codex', options.effort);
+      if (mapped) args.push(mapped.flag, mapped.value);
     }
 
     if (options.extraArgs) {

--- a/src/adapters/index.test.ts
+++ b/src/adapters/index.test.ts
@@ -3,7 +3,7 @@ import { getAdapter } from './index.js';
 import type { CliName } from '../types.js';
 
 describe('getAdapter', () => {
-  const cliNames: CliName[] = ['claude', 'codex', 'opencode'];
+  const cliNames: CliName[] = ['claude', 'codex', 'opencode', 'pi'];
 
   for (const name of cliNames) {
     it(`returns adapter with name '${name}'`, () => {
@@ -57,5 +57,14 @@ describe('getAdapter', () => {
     expect(result.bin).toBe('opencode');
     expect(result.args).toContain('run');
     expect(result.stdinInput).toBe('hi');
+  });
+
+  it('pi adapter buildCommand returns valid command', () => {
+    const adapter = getAdapter('pi');
+    const result = adapter.buildCommand({ cli: 'pi', prompt: 'hi', cwd: '/tmp' });
+    expect(result.bin).toBe('pi');
+    expect(result.args).toContain('--mode');
+    expect(result.args).toContain('json');
+    expect(result.args).toContain('hi');
   });
 });

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -3,11 +3,13 @@ import type { CliAdapter } from './types.js';
 import { claudeAdapter } from './claude.js';
 import { codexAdapter } from './codex.js';
 import { opencodeAdapter } from './opencode.js';
+import { piAdapter } from './pi.js';
 
 const adapters: Record<CliName, CliAdapter> = {
   claude: claudeAdapter,
   codex: codexAdapter,
   opencode: opencodeAdapter,
+  pi: piAdapter,
 };
 
 export function getAdapter(cli: CliName): CliAdapter {

--- a/src/adapters/pi.ts
+++ b/src/adapters/pi.ts
@@ -1,16 +1,12 @@
-import type { CliEvent, CliError, DetectResult, EffortLevel, SpawnOptions } from '../types.js';
+import type { CliEvent, CliError, DetectResult, SpawnOptions } from '../types.js';
 import type { CliAdapter, SessionAccumulator } from './types.js';
 import { execCommand } from '../core/detect.js';
 import type { ExecResult } from '../core/detect.js';
 import { classifyErrorDefault } from '../core/errors.js';
+import { mapEffortToCliFlag } from '../core/effort.js';
 
 function isExecResult(result: Awaited<ReturnType<typeof execCommand>>): result is ExecResult {
   return 'exitCode' in result;
-}
-
-function mapEffortToThinking(effort: EffortLevel): string {
-  if (effort === 'max' || effort === 'xhigh') return 'xhigh';
-  return effort;
 }
 
 export const piAdapter: CliAdapter = {
@@ -63,7 +59,8 @@ export const piAdapter: CliAdapter = {
     }
 
     if (options.effort) {
-      args.push('--thinking', mapEffortToThinking(options.effort));
+      const mapped = mapEffortToCliFlag('pi', options.effort);
+      if (mapped) args.push(mapped.flag, mapped.value);
     }
 
     if (options.extraArgs) {

--- a/src/adapters/pi.ts
+++ b/src/adapters/pi.ts
@@ -5,8 +5,20 @@ import type { ExecResult } from '../core/detect.js';
 import { classifyErrorDefault } from '../core/errors.js';
 import { mapEffortToCliFlag } from '../core/effort.js';
 
+const UNKNOWN_ERROR = 'unknown error';
+const UNKNOWN_TOOL = 'unknown';
+const TOOL_FAILURE_FALLBACK = 'tool execution failed';
+
 function isExecResult(result: Awaited<ReturnType<typeof execCommand>>): result is ExecResult {
   return 'exitCode' in result;
+}
+
+function asString(v: unknown): string | null {
+  return typeof v === 'string' ? v : null;
+}
+
+function asRecord(v: unknown): Record<string, unknown> | null {
+  return v && typeof v === 'object' && !Array.isArray(v) ? (v as Record<string, unknown>) : null;
 }
 
 export const piAdapter: CliAdapter = {
@@ -86,14 +98,17 @@ export const piAdapter: CliAdapter = {
 
     switch (json.type) {
       case 'session': {
-        const sessionId = (json.id as string) ?? null;
-        const model = (json.model as string) ?? null;
+        const sessionId = asString(json.id);
+        const model = asString(json.model);
         if (sessionId) accumulator.sessionId = sessionId;
         if (model) accumulator.model = model;
         const parts: string[] = [];
         if (sessionId) parts.push(`session=${sessionId}`);
         if (model) parts.push(`model=${model}`);
-        return [{ type: 'system', content: parts.join(', ') || 'session', timestamp: now, raw: line }];
+        // If neither id nor model are present the event carries no useful state
+        // for downstream consumers — drop it rather than emit a placeholder.
+        if (parts.length === 0) return [];
+        return [{ type: 'system', content: parts.join(', '), timestamp: now, raw: line }];
       }
 
       case 'agent_start':
@@ -103,33 +118,35 @@ export const piAdapter: CliAdapter = {
         return [{ type: 'system', content: 'turn_start', timestamp: now, raw: line }];
 
       case 'message_start': {
-        const message = json.message as Record<string, unknown> | undefined;
+        // Pi can switch models mid-session via --models cycling, so we refresh
+        // accumulator.model here in addition to the initial `session` event.
+        const message = asRecord(json.message);
         if (message?.role === 'assistant') {
-          const model = (message.model as string) ?? null;
+          const model = asString(message.model);
           if (model) accumulator.model = model;
         }
         return [];
       }
 
       case 'message_update': {
-        const assistantEvent = json.assistantMessageEvent as Record<string, unknown> | undefined;
+        const assistantEvent = asRecord(json.assistantMessageEvent);
         if (!assistantEvent) return [];
 
-        const eventType = assistantEvent.type as string;
+        const eventType = asString(assistantEvent.type);
 
         if (eventType === 'text_end') {
-          const content = assistantEvent.content as string;
+          const content = asString(assistantEvent.content);
           return [{ type: 'text', content: content ?? '', timestamp: now, raw: line }];
         }
 
         if (eventType === 'toolcall_end') {
-          const toolCall = assistantEvent.toolCall as Record<string, unknown> | undefined;
+          const toolCall = asRecord(assistantEvent.toolCall);
           if (toolCall) {
             return [{
               type: 'tool_use',
               tool: {
-                name: (toolCall.name as string) ?? 'unknown',
-                input: (toolCall.arguments as Record<string, unknown>) ?? {},
+                name: asString(toolCall.name) ?? UNKNOWN_TOOL,
+                input: asRecord(toolCall.arguments) ?? {},
               },
               timestamp: now,
               raw: line,
@@ -138,8 +155,8 @@ export const piAdapter: CliAdapter = {
         }
 
         if (eventType === 'error') {
-          const errObj = assistantEvent.error as Record<string, unknown> | undefined;
-          const errorMsg = (errObj?.errorMessage as string) ?? 'unknown error';
+          const errObj = asRecord(assistantEvent.error);
+          const errorMsg = asString(errObj?.errorMessage) ?? UNKNOWN_ERROR;
           return [{ type: 'error', content: errorMsg, timestamp: now, raw: line }];
         }
 
@@ -149,46 +166,43 @@ export const piAdapter: CliAdapter = {
       }
 
       case 'message_end': {
-        const message = json.message as Record<string, unknown> | undefined;
+        // Usage is intentionally ignored here — pi emits the same usage block
+        // again in turn_end, and may emit multiple message_end events per turn
+        // (some with null usage). We accumulate only at turn_end to have a
+        // single source of truth that works correctly across multi-turn sessions.
+        const message = asRecord(json.message);
         if (message?.role === 'assistant') {
-          const usage = message.usage as Record<string, unknown> | undefined;
-          if (usage) {
-            const input = usage.input as number | undefined;
-            const output = usage.output as number | undefined;
-            if (typeof input === 'number') accumulator.inputTokens = input;
-            if (typeof output === 'number') accumulator.outputTokens = output;
-            const cost = (usage.cost as Record<string, unknown> | undefined)?.total as number | undefined;
-            if (typeof cost === 'number') accumulator.cost = cost;
-          }
-
-          const stopReason = message.stopReason as string | undefined;
+          const stopReason = asString(message.stopReason);
           if (stopReason === 'error' || stopReason === 'aborted') {
-            const errorMessage = (message.errorMessage as string) ?? `Request ${stopReason}`;
+            const errorMessage = asString(message.errorMessage) ?? `Request ${stopReason}`;
             return [{ type: 'error', content: errorMessage, timestamp: now, raw: line }];
           }
         }
         return [];
       }
 
+      // Skipped — tool_execution_end carries the final result we surface.
       case 'tool_execution_start':
       case 'tool_execution_update':
         return [];
 
       case 'tool_execution_end': {
-        const toolCallId = json.toolCallId as string | undefined;
-        const toolName = json.toolName as string | undefined;
-        const result = json.result as Record<string, unknown> | undefined;
-        const isError = json.isError as boolean | undefined;
+        const toolName = asString(json.toolName);
+        const result = asRecord(json.result);
+        const isError = json.isError === true;
 
-        const content = result?.content as Array<Record<string, unknown>> | undefined;
-        const text = (content?.find((c) => c.type === 'text')?.text as string) ?? '';
+        const content = Array.isArray(result?.content) ? (result.content as Array<Record<string, unknown>>) : undefined;
+        const text = asString(content?.find((c) => c.type === 'text')?.text) ?? '';
 
+        // When isError is true, pi exposes the failure text only via result.content,
+        // so we surface the same string in both `output` (raw payload) and `error`
+        // (failure marker). Consumers should branch on `error` being defined.
         return [{
           type: 'tool_result',
           toolResult: {
-            name: toolName ?? toolCallId ?? 'unknown',
+            name: toolName ?? UNKNOWN_TOOL,
             output: text,
-            error: isError ? text || 'tool execution failed' : undefined,
+            error: isError ? text || TOOL_FAILURE_FALLBACK : undefined,
           },
           timestamp: now,
           raw: line,
@@ -196,24 +210,27 @@ export const piAdapter: CliAdapter = {
       }
 
       case 'turn_end': {
-        const message = json.message as Record<string, unknown> | undefined;
+        const message = asRecord(json.message);
         if (message) {
-          const model = (message.model as string) ?? null;
+          const model = asString(message.model);
           if (model) accumulator.model = model;
 
-          const usage = message.usage as Record<string, unknown> | undefined;
+          // pi reports per-turn usage (verified empirically across two-turn
+          // sessions), so we accumulate to track session totals — matching
+          // claude/codex semantics.
+          const usage = asRecord(message.usage);
           if (usage) {
-            const input = usage.input as number | undefined;
-            const output = usage.output as number | undefined;
-            if (typeof input === 'number') accumulator.inputTokens = input;
-            if (typeof output === 'number') accumulator.outputTokens = output;
-            const cost = (usage.cost as Record<string, unknown> | undefined)?.total as number | undefined;
-            if (typeof cost === 'number') accumulator.cost = cost;
+            const input = usage.input;
+            const output = usage.output;
+            if (typeof input === 'number') accumulator.inputTokens += input;
+            if (typeof output === 'number') accumulator.outputTokens += output;
+            const cost = asRecord(usage.cost)?.total;
+            if (typeof cost === 'number') accumulator.cost = (accumulator.cost ?? 0) + cost;
           }
 
-          const stopReason = message.stopReason as string | undefined;
+          const stopReason = asString(message.stopReason);
           if (stopReason === 'error' || stopReason === 'aborted') {
-            const errorMessage = (message.errorMessage as string) ?? `Request ${stopReason}`;
+            const errorMessage = asString(message.errorMessage) ?? `Request ${stopReason}`;
             return [{ type: 'error', content: errorMessage, timestamp: now, raw: line }];
           }
         }
@@ -229,27 +246,20 @@ export const piAdapter: CliAdapter = {
   },
 
   classifyError(exitCode: number, stderr: string, stdout: string): CliError {
-    const combined = stderr + '\n' + stdout;
-    const raw = stderr + (stdout ? '\n' + stdout : '');
+    const raw = [stderr, stdout].filter(Boolean).join('\n');
 
-    if (/model.*not found|not found.*model|unknown model/i.test(combined)) {
-      const matchedLine = combined.split('\n').find((l) => /model.*not found|not found.*model|unknown model/i.test(l))?.trim() || 'Model not found';
-      return { code: 'model_not_found', message: matchedLine, retryable: false, retryAfterMs: null, raw };
-    }
+    const PATTERNS = [
+      { code: 'model_not_found' as const, regex: /model.*not found|not found.*model|unknown model/i, retryable: false, fallback: 'Model not found' },
+      { code: 'auth' as const,            regex: /api key|unauthorized|authentication/i,             retryable: false, fallback: 'Authentication required' },
+      { code: 'rate_limit' as const,      regex: /rate limit|too many requests|ratelimit/i,          retryable: true,  fallback: 'Rate limited' },
+      { code: 'context_overflow' as const,regex: /context.*length|too long|token limit|maximum context|context window/i, retryable: false, fallback: 'Context overflow' },
+    ];
 
-    if (/api key|unauthorized|authentication/i.test(combined)) {
-      const matchedLine = combined.split('\n').find((l) => /api key|unauthorized|authentication/i.test(l))?.trim() || 'Authentication required';
-      return { code: 'auth', message: matchedLine, retryable: false, retryAfterMs: null, raw };
-    }
-
-    if (/rate limit|too many requests|ratelimit/i.test(combined)) {
-      const matchedLine = combined.split('\n').find((l) => /rate limit|too many requests|ratelimit/i.test(l))?.trim() || 'Rate limited';
-      return { code: 'rate_limit', message: matchedLine, retryable: true, retryAfterMs: null, raw };
-    }
-
-    if (/context.*length|too long|token limit|maximum context|context window/i.test(combined)) {
-      const matchedLine = combined.split('\n').find((l) => /context.*length|too long|token limit|maximum context|context window/i.test(l))?.trim() || 'Context overflow';
-      return { code: 'context_overflow', message: matchedLine, retryable: false, retryAfterMs: null, raw };
+    for (const { code, regex, retryable, fallback } of PATTERNS) {
+      const matchedLine = raw.split('\n').find((l) => regex.test(l))?.trim();
+      if (matchedLine !== undefined) {
+        return { code, message: matchedLine || fallback, retryable, retryAfterMs: null, raw };
+      }
     }
 
     return classifyErrorDefault(exitCode, stderr, stdout);

--- a/src/adapters/pi.ts
+++ b/src/adapters/pi.ts
@@ -1,0 +1,260 @@
+import type { CliEvent, CliError, DetectResult, EffortLevel, SpawnOptions } from '../types.js';
+import type { CliAdapter, SessionAccumulator } from './types.js';
+import { execCommand } from '../core/detect.js';
+import type { ExecResult } from '../core/detect.js';
+import { classifyErrorDefault } from '../core/errors.js';
+
+function isExecResult(result: Awaited<ReturnType<typeof execCommand>>): result is ExecResult {
+  return 'exitCode' in result;
+}
+
+function mapEffortToThinking(effort: EffortLevel): string {
+  if (effort === 'max' || effort === 'xhigh') return 'xhigh';
+  return effort;
+}
+
+export const piAdapter: CliAdapter = {
+  name: 'pi',
+
+  async detect(): Promise<DetectResult> {
+    const versionResult = await execCommand('pi', ['--version']);
+
+    if (!isExecResult(versionResult)) {
+      if (versionResult.kind === 'enoent') {
+        return { installed: false, version: null, authenticated: false, binaryPath: null };
+      }
+      return { installed: true, version: null, authenticated: false, binaryPath: 'pi' };
+    }
+
+    const version = versionResult.stdout.trim() || null;
+
+    // Pi auth is provider-specific and runtime-determined; optimistically report
+    // authenticated. Real failures surface at runtime via classifyError.
+    return { installed: true, version, authenticated: true, binaryPath: 'pi' };
+  },
+
+  buildCommand(options: SpawnOptions) {
+    const args: string[] = ['--mode', 'json'];
+
+    if (options.model) {
+      args.push('--model', options.model);
+    }
+
+    if (options.sessionId) {
+      args.push('--session', options.sessionId);
+    } else if (options.continueSession) {
+      args.push('--continue');
+    }
+
+    if (options.forkSession && options.sessionId) {
+      const sessionIndex = args.indexOf('--session');
+      if (sessionIndex !== -1) args.splice(sessionIndex, 2);
+      const continueIndex = args.indexOf('--continue');
+      if (continueIndex !== -1) args.splice(continueIndex, 1);
+      args.push('--fork', options.sessionId);
+    }
+
+    if (options.ephemeral) {
+      args.push('--no-session');
+    }
+
+    if (options.verbose) {
+      args.push('--verbose');
+    }
+
+    if (options.effort) {
+      args.push('--thinking', mapEffortToThinking(options.effort));
+    }
+
+    if (options.extraArgs) {
+      args.push(...options.extraArgs);
+    }
+
+    args.push(options.prompt);
+
+    return { bin: 'pi', args };
+  },
+
+  parseLine(line: string, accumulator: SessionAccumulator): CliEvent[] {
+    if (!line.trim()) return [];
+
+    let json: Record<string, unknown>;
+    try {
+      json = JSON.parse(line);
+    } catch {
+      return [{ type: 'system', content: line, timestamp: Date.now(), raw: line }];
+    }
+
+    const now = Date.now();
+
+    switch (json.type) {
+      case 'session': {
+        const sessionId = (json.id as string) ?? null;
+        const model = (json.model as string) ?? null;
+        if (sessionId) accumulator.sessionId = sessionId;
+        if (model) accumulator.model = model;
+        const parts: string[] = [];
+        if (sessionId) parts.push(`session=${sessionId}`);
+        if (model) parts.push(`model=${model}`);
+        return [{ type: 'system', content: parts.join(', ') || 'session', timestamp: now, raw: line }];
+      }
+
+      case 'agent_start':
+        return [{ type: 'system', content: 'agent_start', timestamp: now, raw: line }];
+
+      case 'turn_start':
+        return [{ type: 'system', content: 'turn_start', timestamp: now, raw: line }];
+
+      case 'message_start': {
+        const message = json.message as Record<string, unknown> | undefined;
+        if (message?.role === 'assistant') {
+          const model = (message.model as string) ?? null;
+          if (model) accumulator.model = model;
+        }
+        return [];
+      }
+
+      case 'message_update': {
+        const assistantEvent = json.assistantMessageEvent as Record<string, unknown> | undefined;
+        if (!assistantEvent) return [];
+
+        const eventType = assistantEvent.type as string;
+
+        if (eventType === 'text_end') {
+          const content = assistantEvent.content as string;
+          return [{ type: 'text', content: content ?? '', timestamp: now, raw: line }];
+        }
+
+        if (eventType === 'toolcall_end') {
+          const toolCall = assistantEvent.toolCall as Record<string, unknown> | undefined;
+          if (toolCall) {
+            return [{
+              type: 'tool_use',
+              tool: {
+                name: (toolCall.name as string) ?? 'unknown',
+                input: (toolCall.arguments as Record<string, unknown>) ?? {},
+              },
+              timestamp: now,
+              raw: line,
+            }];
+          }
+        }
+
+        if (eventType === 'error') {
+          const errObj = assistantEvent.error as Record<string, unknown> | undefined;
+          const errorMsg = (errObj?.errorMessage as string) ?? 'unknown error';
+          return [{ type: 'error', content: errorMsg, timestamp: now, raw: line }];
+        }
+
+        // thinking_start, thinking_delta, thinking_end and other unhandled
+        // assistant events are intentionally skipped.
+        return [];
+      }
+
+      case 'message_end': {
+        const message = json.message as Record<string, unknown> | undefined;
+        if (message?.role === 'assistant') {
+          const usage = message.usage as Record<string, unknown> | undefined;
+          if (usage) {
+            const input = usage.input as number | undefined;
+            const output = usage.output as number | undefined;
+            if (typeof input === 'number') accumulator.inputTokens = input;
+            if (typeof output === 'number') accumulator.outputTokens = output;
+            const cost = (usage.cost as Record<string, unknown> | undefined)?.total as number | undefined;
+            if (typeof cost === 'number') accumulator.cost = cost;
+          }
+
+          const stopReason = message.stopReason as string | undefined;
+          if (stopReason === 'error' || stopReason === 'aborted') {
+            const errorMessage = (message.errorMessage as string) ?? `Request ${stopReason}`;
+            return [{ type: 'error', content: errorMessage, timestamp: now, raw: line }];
+          }
+        }
+        return [];
+      }
+
+      case 'tool_execution_start':
+      case 'tool_execution_update':
+        return [];
+
+      case 'tool_execution_end': {
+        const toolCallId = json.toolCallId as string | undefined;
+        const toolName = json.toolName as string | undefined;
+        const result = json.result as Record<string, unknown> | undefined;
+        const isError = json.isError as boolean | undefined;
+
+        const content = result?.content as Array<Record<string, unknown>> | undefined;
+        const text = (content?.find((c) => c.type === 'text')?.text as string) ?? '';
+
+        return [{
+          type: 'tool_result',
+          toolResult: {
+            name: toolName ?? toolCallId ?? 'unknown',
+            output: text,
+            error: isError ? text || 'tool execution failed' : undefined,
+          },
+          timestamp: now,
+          raw: line,
+        }];
+      }
+
+      case 'turn_end': {
+        const message = json.message as Record<string, unknown> | undefined;
+        if (message) {
+          const model = (message.model as string) ?? null;
+          if (model) accumulator.model = model;
+
+          const usage = message.usage as Record<string, unknown> | undefined;
+          if (usage) {
+            const input = usage.input as number | undefined;
+            const output = usage.output as number | undefined;
+            if (typeof input === 'number') accumulator.inputTokens = input;
+            if (typeof output === 'number') accumulator.outputTokens = output;
+            const cost = (usage.cost as Record<string, unknown> | undefined)?.total as number | undefined;
+            if (typeof cost === 'number') accumulator.cost = cost;
+          }
+
+          const stopReason = message.stopReason as string | undefined;
+          if (stopReason === 'error' || stopReason === 'aborted') {
+            const errorMessage = (message.errorMessage as string) ?? `Request ${stopReason}`;
+            return [{ type: 'error', content: errorMessage, timestamp: now, raw: line }];
+          }
+        }
+        return [{ type: 'system', content: 'turn_end', timestamp: now, raw: line }];
+      }
+
+      case 'agent_end':
+        return [{ type: 'system', content: 'agent_end', timestamp: now, raw: line }];
+
+      default:
+        return [{ type: 'system', content: line, timestamp: now, raw: line }];
+    }
+  },
+
+  classifyError(exitCode: number, stderr: string, stdout: string): CliError {
+    const combined = stderr + '\n' + stdout;
+    const raw = stderr + (stdout ? '\n' + stdout : '');
+
+    if (/model.*not found|not found.*model|unknown model/i.test(combined)) {
+      const matchedLine = combined.split('\n').find((l) => /model.*not found|not found.*model|unknown model/i.test(l))?.trim() || 'Model not found';
+      return { code: 'model_not_found', message: matchedLine, retryable: false, retryAfterMs: null, raw };
+    }
+
+    if (/api key|unauthorized|authentication/i.test(combined)) {
+      const matchedLine = combined.split('\n').find((l) => /api key|unauthorized|authentication/i.test(l))?.trim() || 'Authentication required';
+      return { code: 'auth', message: matchedLine, retryable: false, retryAfterMs: null, raw };
+    }
+
+    if (/rate limit|too many requests|ratelimit/i.test(combined)) {
+      const matchedLine = combined.split('\n').find((l) => /rate limit|too many requests|ratelimit/i.test(l))?.trim() || 'Rate limited';
+      return { code: 'rate_limit', message: matchedLine, retryable: true, retryAfterMs: null, raw };
+    }
+
+    if (/context.*length|too long|token limit|maximum context|context window/i.test(combined)) {
+      const matchedLine = combined.split('\n').find((l) => /context.*length|too long|token limit|maximum context|context window/i.test(l))?.trim() || 'Context overflow';
+      return { code: 'context_overflow', message: matchedLine, retryable: false, retryAfterMs: null, raw };
+    }
+
+    return classifyErrorDefault(exitCode, stderr, stdout);
+  },
+};

--- a/src/core/detect.ts
+++ b/src/core/detect.ts
@@ -62,11 +62,12 @@ export async function detect(cli: CliName): Promise<DetectResult> {
 }
 
 export async function detectAll(): Promise<Record<CliName, DetectResult>> {
-  const clis: CliName[] = ['claude', 'codex', 'opencode'];
+  const clis: CliName[] = ['claude', 'codex', 'opencode', 'pi'];
   const results = await Promise.all(clis.map((cli) => detect(cli)));
   return {
     claude: results[0],
     codex: results[1],
     opencode: results[2],
+    pi: results[3],
   };
 }

--- a/src/core/effort.ts
+++ b/src/core/effort.ts
@@ -1,0 +1,27 @@
+import type { CliName, EffortLevel } from '../types.js';
+
+export interface EffortFlag {
+  flag: string;
+  value: string;
+}
+
+export function mapEffortToCliFlag(cli: CliName, effort: EffortLevel): EffortFlag | null {
+  switch (cli) {
+    case 'claude': {
+      if (effort === 'off' || effort === 'minimal') return null;
+      const value = effort === 'xhigh' ? 'max' : effort;
+      return { flag: '--effort', value };
+    }
+    case 'codex': {
+      if (effort === 'off' || effort === 'minimal') return null;
+      const mapped = effort === 'max' || effort === 'xhigh' ? 'high' : effort;
+      return { flag: '-c', value: `model_reasoning_effort=${mapped}` };
+    }
+    case 'pi': {
+      const value = effort === 'max' || effort === 'xhigh' ? 'xhigh' : effort;
+      return { flag: '--thinking', value };
+    }
+    case 'opencode':
+      return null;
+  }
+}

--- a/src/core/effort.ts
+++ b/src/core/effort.ts
@@ -23,5 +23,9 @@ export function mapEffortToCliFlag(cli: CliName, effort: EffortLevel): EffortFla
     }
     case 'opencode':
       return null;
+    default: {
+      const _exhaustive: never = cli;
+      return _exhaustive;
+    }
   }
 }

--- a/src/models.test.ts
+++ b/src/models.test.ts
@@ -66,6 +66,10 @@ describe('CLI_PROVIDER_MAP', () => {
   it('maps opencode to null', () => {
     expect(CLI_PROVIDER_MAP.opencode).toBeNull();
   });
+
+  it('maps pi to null (provider-agnostic)', () => {
+    expect(CLI_PROVIDER_MAP.pi).toBeNull();
+  });
 });
 
 describe('listModels', () => {
@@ -90,6 +94,14 @@ describe('listModels', () => {
     const models = await listModels({ cli: 'codex' });
     expect(models.every(m => m.provider === 'openai')).toBe(true);
     expect(models.length).toBe(1);
+  });
+
+  it('cli=pi returns all models.dev models (provider-agnostic)', async () => {
+    mockFetchSuccess();
+    const models = await listModels({ cli: 'pi' });
+    expect(models.length).toBe(4); // all providers, no filter
+    const providers = new Set(models.map(m => m.provider));
+    expect(providers.size).toBeGreaterThan(1);
   });
 
   it('routes cli=opencode to CLI discovery (not models.dev)', async () => {

--- a/src/models.test.ts
+++ b/src/models.test.ts
@@ -51,8 +51,8 @@ afterEach(() => {
 });
 
 describe('CLI_PROVIDER_MAP', () => {
-  it('has entries for all three CliName values', () => {
-    expect(Object.keys(CLI_PROVIDER_MAP)).toEqual(['claude', 'codex', 'opencode']);
+  it('has entries for all CliName values', () => {
+    expect(Object.keys(CLI_PROVIDER_MAP)).toEqual(['claude', 'codex', 'opencode', 'pi']);
   });
 
   it('maps claude to anthropic', () => {

--- a/src/models.test.ts
+++ b/src/models.test.ts
@@ -52,7 +52,9 @@ afterEach(() => {
 
 describe('CLI_PROVIDER_MAP', () => {
   it('has entries for all CliName values', () => {
-    expect(Object.keys(CLI_PROVIDER_MAP)).toEqual(['claude', 'codex', 'opencode', 'pi']);
+    const keys = Object.keys(CLI_PROVIDER_MAP);
+    expect(keys).toHaveLength(4);
+    expect(keys).toEqual(expect.arrayContaining(['claude', 'codex', 'opencode', 'pi']));
   });
 
   it('maps claude to anthropic', () => {

--- a/src/models.ts
+++ b/src/models.ts
@@ -9,6 +9,7 @@ export const CLI_PROVIDER_MAP: Record<CliName, string | null> = {
   claude: 'anthropic',
   codex: 'openai',
   opencode: null,
+  pi: null,
 };
 
 export async function listModels(options?: ListModelsOptions): Promise<KnownModel[]> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,8 @@
 // --- Union types ---
 
-export type CliName = 'claude' | 'codex' | 'opencode';
+export type CliName = 'claude' | 'codex' | 'opencode' | 'pi';
+
+export type EffortLevel = 'off' | 'minimal' | 'low' | 'medium' | 'high' | 'max' | 'xhigh';
 
 export type CliEventType =
   | 'text'
@@ -29,7 +31,7 @@ export interface SpawnOptions {
   cwd: string;
   model?: string;
   sessionId?: string;
-  effort?: 'low' | 'medium' | 'high' | 'max';
+  effort?: EffortLevel;
   autoApprove?: boolean;
   forkSession?: boolean;
   continueSession?: boolean;

--- a/test/adapters/pi.test.ts
+++ b/test/adapters/pi.test.ts
@@ -204,7 +204,7 @@ describe('piAdapter.parseLine', () => {
     expect(events[0].toolResult?.error).toBe('boom');
   });
 
-  it('message_end accumulates token usage and cost', () => {
+  it('message_end does not accumulate usage (turn_end is the source of truth)', () => {
     const line = JSON.stringify({
       type: 'message_end',
       message: {
@@ -213,9 +213,25 @@ describe('piAdapter.parseLine', () => {
       },
     });
     piAdapter.parseLine(line, acc);
-    expect(acc.inputTokens).toBe(100);
-    expect(acc.outputTokens).toBe(50);
-    expect(acc.cost).toBe(0.0042);
+    expect(acc.inputTokens).toBe(0);
+    expect(acc.outputTokens).toBe(0);
+    expect(acc.cost).toBeNull();
+  });
+
+  it('turn_end accumulates across multiple turns (per-turn semantics)', () => {
+    const turn1 = JSON.stringify({
+      type: 'turn_end',
+      message: { usage: { input: 16, output: 38, cost: { total: 0.0001 } } },
+    });
+    const turn2 = JSON.stringify({
+      type: 'turn_end',
+      message: { usage: { input: 40, output: 29, cost: { total: 0.0003 } } },
+    });
+    piAdapter.parseLine(turn1, acc);
+    piAdapter.parseLine(turn2, acc);
+    expect(acc.inputTokens).toBe(56);
+    expect(acc.outputTokens).toBe(67);
+    expect(acc.cost).toBeCloseTo(0.0004, 6);
   });
 
   it('message_end with stopReason=error emits error event', () => {
@@ -312,7 +328,7 @@ describe('piAdapter parseLine (fixture-based)', () => {
       expect(textEvents[0].content).toBe('Hello from pi!');
     });
 
-    it('accumulates token usage and cost from message_end / turn_end', () => {
+    it('accumulates token usage and cost from turn_end', () => {
       const lines = fixture('text-response.jsonl');
       parseAll(lines, acc);
       expect(acc.inputTokens).toBe(42);

--- a/test/adapters/pi.test.ts
+++ b/test/adapters/pi.test.ts
@@ -1,0 +1,312 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { piAdapter } from '../../src/adapters/pi.js';
+import { createAccumulator, type SessionAccumulator } from '../../src/adapters/types.js';
+
+function parseAll(lines: string[], acc: SessionAccumulator) {
+  return lines.flatMap((line) => piAdapter.parseLine(line, acc));
+}
+
+describe('piAdapter shape', () => {
+  it('has name "pi" and all required methods', () => {
+    expect(piAdapter.name).toBe('pi');
+    expect(typeof piAdapter.buildCommand).toBe('function');
+    expect(typeof piAdapter.parseLine).toBe('function');
+    expect(typeof piAdapter.detect).toBe('function');
+    expect(typeof piAdapter.classifyError).toBe('function');
+  });
+});
+
+describe('piAdapter.buildCommand', () => {
+  const base = { cli: 'pi' as const, prompt: 'hello', cwd: '/tmp' };
+
+  it('builds basic command with --mode json and prompt as last positional', () => {
+    const { bin, args } = piAdapter.buildCommand(base);
+    expect(bin).toBe('pi');
+    expect(args[0]).toBe('--mode');
+    expect(args[1]).toBe('json');
+    expect(args[args.length - 1]).toBe('hello');
+  });
+
+  it('adds --model when model option is provided', () => {
+    const { args } = piAdapter.buildCommand({ ...base, model: 'gpt-5' });
+    const i = args.indexOf('--model');
+    expect(i).toBeGreaterThanOrEqual(0);
+    expect(args[i + 1]).toBe('gpt-5');
+    expect(args.indexOf('--model')).toBeLessThan(args.length - 1);
+  });
+
+  it('adds --session for sessionId', () => {
+    const { args } = piAdapter.buildCommand({ ...base, sessionId: 'sess-1' });
+    const i = args.indexOf('--session');
+    expect(i).toBeGreaterThanOrEqual(0);
+    expect(args[i + 1]).toBe('sess-1');
+  });
+
+  it('adds --continue for continueSession', () => {
+    const { args } = piAdapter.buildCommand({ ...base, continueSession: true });
+    expect(args).toContain('--continue');
+  });
+
+  it('forkSession with sessionId strips --session/--continue and adds --fork', () => {
+    const { args } = piAdapter.buildCommand({
+      ...base,
+      sessionId: 'sess-1',
+      continueSession: true,
+      forkSession: true,
+    });
+    expect(args).not.toContain('--session');
+    expect(args).not.toContain('--continue');
+    const i = args.indexOf('--fork');
+    expect(i).toBeGreaterThanOrEqual(0);
+    expect(args[i + 1]).toBe('sess-1');
+  });
+
+  it('forkSession without sessionId is a no-op (no --fork)', () => {
+    const { args } = piAdapter.buildCommand({ ...base, forkSession: true });
+    expect(args).not.toContain('--fork');
+  });
+
+  it('adds --no-session for ephemeral', () => {
+    const { args } = piAdapter.buildCommand({ ...base, ephemeral: true });
+    expect(args).toContain('--no-session');
+  });
+
+  it('adds --verbose when verbose is true', () => {
+    const { args } = piAdapter.buildCommand({ ...base, verbose: true });
+    expect(args).toContain('--verbose');
+  });
+
+  it('maps effort to --thinking flag', () => {
+    const { args } = piAdapter.buildCommand({ ...base, effort: 'high' });
+    const i = args.indexOf('--thinking');
+    expect(i).toBeGreaterThanOrEqual(0);
+    expect(args[i + 1]).toBe('high');
+  });
+
+  it('maps effort=max and effort=xhigh to --thinking xhigh', () => {
+    const max = piAdapter.buildCommand({ ...base, effort: 'max' });
+    const xhigh = piAdapter.buildCommand({ ...base, effort: 'xhigh' });
+    expect(max.args[max.args.indexOf('--thinking') + 1]).toBe('xhigh');
+    expect(xhigh.args[xhigh.args.indexOf('--thinking') + 1]).toBe('xhigh');
+  });
+
+  it('maps effort=off and effort=minimal to --thinking off/minimal', () => {
+    const off = piAdapter.buildCommand({ ...base, effort: 'off' });
+    const minimal = piAdapter.buildCommand({ ...base, effort: 'minimal' });
+    expect(off.args[off.args.indexOf('--thinking') + 1]).toBe('off');
+    expect(minimal.args[minimal.args.indexOf('--thinking') + 1]).toBe('minimal');
+  });
+
+  it('inserts extraArgs before the positional prompt', () => {
+    const { args } = piAdapter.buildCommand({ ...base, extraArgs: ['--foo', 'bar'] });
+    const promptIdx = args.lastIndexOf('hello');
+    expect(args.indexOf('--foo')).toBeLessThan(promptIdx);
+    expect(args.indexOf('bar')).toBeLessThan(promptIdx);
+  });
+
+  it('passes prompt as positional (no stdin)', () => {
+    const cmd = piAdapter.buildCommand({ ...base });
+    expect(cmd.stdinInput).toBeUndefined();
+    expect(cmd.args[cmd.args.length - 1]).toBe('hello');
+  });
+});
+
+describe('piAdapter.parseLine', () => {
+  let acc: SessionAccumulator;
+
+  beforeEach(() => {
+    acc = createAccumulator();
+  });
+
+  it('returns [] for empty/whitespace lines', () => {
+    expect(piAdapter.parseLine('', acc)).toEqual([]);
+    expect(piAdapter.parseLine('   ', acc)).toEqual([]);
+  });
+
+  it('non-JSON line falls back to system event', () => {
+    const events = piAdapter.parseLine('not json', acc);
+    expect(events).toHaveLength(1);
+    expect(events[0].type).toBe('system');
+    expect(events[0].content).toBe('not json');
+  });
+
+  it('unrecognized event type falls back to system event', () => {
+    const line = JSON.stringify({ type: 'unknown_future_type', foo: 1 });
+    const events = piAdapter.parseLine(line, acc);
+    expect(events).toHaveLength(1);
+    expect(events[0].type).toBe('system');
+  });
+
+  it('session event captures sessionId and model into accumulator', () => {
+    const line = JSON.stringify({ type: 'session', id: 'sess-xyz', model: 'gpt-5' });
+    const events = piAdapter.parseLine(line, acc);
+    expect(acc.sessionId).toBe('sess-xyz');
+    expect(acc.model).toBe('gpt-5');
+    expect(events[0].type).toBe('system');
+  });
+
+  it('message_update with text_end emits text event', () => {
+    const line = JSON.stringify({
+      type: 'message_update',
+      assistantMessageEvent: { type: 'text_end', content: 'Hello world' },
+    });
+    const events = piAdapter.parseLine(line, acc);
+    expect(events).toHaveLength(1);
+    expect(events[0].type).toBe('text');
+    expect(events[0].content).toBe('Hello world');
+  });
+
+  it('message_update with toolcall_end emits tool_use event', () => {
+    const line = JSON.stringify({
+      type: 'message_update',
+      assistantMessageEvent: {
+        type: 'toolcall_end',
+        toolCall: { name: 'bash', arguments: { cmd: 'ls' } },
+      },
+    });
+    const events = piAdapter.parseLine(line, acc);
+    expect(events).toHaveLength(1);
+    expect(events[0].type).toBe('tool_use');
+    expect(events[0].tool).toEqual({ name: 'bash', input: { cmd: 'ls' } });
+  });
+
+  it('tool_execution_end emits tool_result event', () => {
+    const line = JSON.stringify({
+      type: 'tool_execution_end',
+      toolCallId: 'tc-1',
+      toolName: 'bash',
+      result: { content: [{ type: 'text', text: 'output here' }] },
+      isError: false,
+    });
+    const events = piAdapter.parseLine(line, acc);
+    expect(events).toHaveLength(1);
+    expect(events[0].type).toBe('tool_result');
+    expect(events[0].toolResult?.name).toBe('bash');
+    expect(events[0].toolResult?.output).toBe('output here');
+    expect(events[0].toolResult?.error).toBeUndefined();
+  });
+
+  it('tool_execution_end with isError sets toolResult.error', () => {
+    const line = JSON.stringify({
+      type: 'tool_execution_end',
+      toolName: 'bash',
+      result: { content: [{ type: 'text', text: 'boom' }] },
+      isError: true,
+    });
+    const events = piAdapter.parseLine(line, acc);
+    expect(events[0].toolResult?.error).toBe('boom');
+  });
+
+  it('message_end accumulates token usage and cost', () => {
+    const line = JSON.stringify({
+      type: 'message_end',
+      message: {
+        role: 'assistant',
+        usage: { input: 100, output: 50, cost: { total: 0.0042 } },
+      },
+    });
+    piAdapter.parseLine(line, acc);
+    expect(acc.inputTokens).toBe(100);
+    expect(acc.outputTokens).toBe(50);
+    expect(acc.cost).toBe(0.0042);
+  });
+
+  it('message_end with stopReason=error emits error event', () => {
+    const line = JSON.stringify({
+      type: 'message_end',
+      message: { role: 'assistant', stopReason: 'error', errorMessage: 'boom' },
+    });
+    const events = piAdapter.parseLine(line, acc);
+    expect(events).toHaveLength(1);
+    expect(events[0].type).toBe('error');
+    expect(events[0].content).toBe('boom');
+  });
+
+  it('turn_end accumulates usage and emits system event', () => {
+    const line = JSON.stringify({
+      type: 'turn_end',
+      message: {
+        usage: { input: 200, output: 80, cost: { total: 0.01 } },
+      },
+    });
+    const events = piAdapter.parseLine(line, acc);
+    expect(acc.inputTokens).toBe(200);
+    expect(acc.outputTokens).toBe(80);
+    expect(acc.cost).toBe(0.01);
+    expect(events[0].type).toBe('system');
+  });
+
+  it('message_update with assistantMessageEvent.type=error emits error event', () => {
+    const line = JSON.stringify({
+      type: 'message_update',
+      assistantMessageEvent: { type: 'error', error: { errorMessage: 'rate limited' } },
+    });
+    const events = piAdapter.parseLine(line, acc);
+    expect(events[0].type).toBe('error');
+    expect(events[0].content).toBe('rate limited');
+  });
+
+  it('thinking_start/thinking_delta/thinking_end inside message_update are skipped', () => {
+    const start = JSON.stringify({
+      type: 'message_update',
+      assistantMessageEvent: { type: 'thinking_start' },
+    });
+    const delta = JSON.stringify({
+      type: 'message_update',
+      assistantMessageEvent: { type: 'thinking_delta', delta: 'hmm' },
+    });
+    const end = JSON.stringify({
+      type: 'message_update',
+      assistantMessageEvent: { type: 'thinking_end', content: 'done thinking' },
+    });
+    expect(piAdapter.parseLine(start, acc)).toEqual([]);
+    expect(piAdapter.parseLine(delta, acc)).toEqual([]);
+    expect(piAdapter.parseLine(end, acc)).toEqual([]);
+  });
+
+  it('all events have raw and timestamp fields', () => {
+    const lines = [
+      JSON.stringify({ type: 'session', id: 's', model: 'm' }),
+      JSON.stringify({ type: 'agent_start' }),
+      JSON.stringify({
+        type: 'message_update',
+        assistantMessageEvent: { type: 'text_end', content: 'hi' },
+      }),
+    ];
+    const events = parseAll(lines, acc);
+    for (const ev of events) {
+      expect(typeof ev.raw).toBe('string');
+      expect(ev.raw.length).toBeGreaterThan(0);
+      expect(typeof ev.timestamp).toBe('number');
+    }
+  });
+});
+
+describe('piAdapter.classifyError', () => {
+  it('classifies model_not_found from stderr', () => {
+    const err = piAdapter.classifyError(1, 'Error: model not found: foo', '');
+    expect(err.code).toBe('model_not_found');
+    expect(err.retryable).toBe(false);
+  });
+
+  it('classifies auth errors', () => {
+    const err = piAdapter.classifyError(1, 'unauthorized: bad api key', '');
+    expect(err.code).toBe('auth');
+  });
+
+  it('classifies rate limit errors', () => {
+    const err = piAdapter.classifyError(1, 'rate limit exceeded', '');
+    expect(err.code).toBe('rate_limit');
+    expect(err.retryable).toBe(true);
+  });
+
+  it('classifies context_overflow errors', () => {
+    const err = piAdapter.classifyError(1, 'context length exceeded', '');
+    expect(err.code).toBe('context_overflow');
+  });
+
+  it('falls through to default classification for unrecognized errors', () => {
+    const err = piAdapter.classifyError(1, 'something else broke', '');
+    expect(['fatal', 'unknown']).toContain(err.code);
+  });
+});

--- a/test/adapters/pi.test.ts
+++ b/test/adapters/pi.test.ts
@@ -1,9 +1,16 @@
 import { describe, it, expect, beforeEach } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
 import { piAdapter } from '../../src/adapters/pi.js';
 import { createAccumulator, type SessionAccumulator } from '../../src/adapters/types.js';
 
 function parseAll(lines: string[], acc: SessionAccumulator) {
   return lines.flatMap((line) => piAdapter.parseLine(line, acc));
+}
+
+function fixture(name: string): string[] {
+  const content = readFileSync(resolve(__dirname, '../fixtures/pi', name), 'utf-8');
+  return content.split('\n').filter((line) => line !== '');
 }
 
 describe('piAdapter shape', () => {
@@ -279,6 +286,109 @@ describe('piAdapter.parseLine', () => {
       expect(ev.raw.length).toBeGreaterThan(0);
       expect(typeof ev.timestamp).toBe('number');
     }
+  });
+});
+
+describe('piAdapter parseLine (fixture-based)', () => {
+  let acc: SessionAccumulator;
+
+  beforeEach(() => {
+    acc = createAccumulator();
+  });
+
+  describe('text-response.jsonl', () => {
+    it('captures session id and model from session event', () => {
+      const lines = fixture('text-response.jsonl');
+      parseAll(lines, acc);
+      expect(acc.sessionId).toBe('pi-sess-001');
+      expect(acc.model).toBe('gpt-5');
+    });
+
+    it('emits exactly one text event with the assistant content', () => {
+      const lines = fixture('text-response.jsonl');
+      const events = parseAll(lines, acc);
+      const textEvents = events.filter((e) => e.type === 'text');
+      expect(textEvents).toHaveLength(1);
+      expect(textEvents[0].content).toBe('Hello from pi!');
+    });
+
+    it('accumulates token usage and cost from message_end / turn_end', () => {
+      const lines = fixture('text-response.jsonl');
+      parseAll(lines, acc);
+      expect(acc.inputTokens).toBe(42);
+      expect(acc.outputTokens).toBe(12);
+      expect(acc.cost).toBe(0.0003);
+    });
+
+    it('all events have raw and timestamp fields', () => {
+      const lines = fixture('text-response.jsonl');
+      const events = parseAll(lines, acc);
+      for (const ev of events) {
+        expect(typeof ev.raw).toBe('string');
+        expect(ev.raw.length).toBeGreaterThan(0);
+        expect(typeof ev.timestamp).toBe('number');
+        expect(ev.timestamp).toBeGreaterThan(0);
+      }
+    });
+  });
+
+  describe('tool-use.jsonl', () => {
+    it('emits a tool_use event with the correct name and input', () => {
+      const lines = fixture('tool-use.jsonl');
+      const events = parseAll(lines, acc);
+      const toolUses = events.filter((e) => e.type === 'tool_use');
+      expect(toolUses).toHaveLength(1);
+      expect(toolUses[0].tool).toEqual({
+        name: 'read_file',
+        input: { path: '/src/index.ts' },
+      });
+    });
+  });
+
+  describe('tool-result.jsonl', () => {
+    it('emits tool_result events with output and error fields', () => {
+      const lines = fixture('tool-result.jsonl');
+      const events = parseAll(lines, acc);
+      const toolResults = events.filter((e) => e.type === 'tool_result');
+      expect(toolResults).toHaveLength(2);
+      expect(toolResults[0].toolResult?.name).toBe('read_file');
+      expect(toolResults[0].toolResult?.output).toBe('file contents here');
+      expect(toolResults[0].toolResult?.error).toBeUndefined();
+      expect(toolResults[1].toolResult?.name).toBe('bash');
+      expect(toolResults[1].toolResult?.error).toBe('command failed');
+    });
+  });
+
+  describe('session-resume.jsonl', () => {
+    it('captures sessionId and model into the accumulator', () => {
+      const lines = fixture('session-resume.jsonl');
+      parseAll(lines, acc);
+      expect(acc.sessionId).toBe('pi-sess-resume-xyz');
+      expect(acc.model).toBe('claude-sonnet-4-5');
+    });
+  });
+
+  describe('error.jsonl', () => {
+    it('emits an error event from message_end stopReason=error', () => {
+      const lines = fixture('error.jsonl');
+      const events = parseAll(lines, acc);
+      const errors = events.filter((e) => e.type === 'error');
+      expect(errors).toHaveLength(1);
+      expect(errors[0].content).toBe('upstream provider error');
+    });
+  });
+
+  describe('malformed.jsonl', () => {
+    it('falls back to system events for non-JSON lines', () => {
+      const lines = fixture('malformed.jsonl');
+      const events = parseAll(lines, acc);
+      const systemEvents = events.filter((e) => e.type === 'system');
+      // Three of the four lines are non-JSON; the valid session line also emits a system event.
+      expect(systemEvents.length).toBeGreaterThanOrEqual(3);
+      const nonJsonContents = systemEvents.map((e) => e.content);
+      expect(nonJsonContents).toContain('this is not json');
+      expect(nonJsonContents).toContain('plain text line');
+    });
   });
 });
 

--- a/test/core/detect.test.ts
+++ b/test/core/detect.test.ts
@@ -132,8 +132,36 @@ describe('detect (mocked child_process)', () => {
     });
   });
 
+  describe('pi', () => {
+    it("detect('pi') returns installed: false when version check gets ENOENT", async () => {
+      mockQueue.push(createEnoentProcess());
+
+      const result = await detect('pi');
+
+      expect(result).toEqual({
+        installed: false,
+        version: null,
+        authenticated: false,
+        binaryPath: null,
+      });
+    });
+
+    it("detect('pi') reports authenticated: true optimistically when binary is present", async () => {
+      mockQueue.push(createMockProcess({ stdoutLines: ['pi 0.1.0'], exitCode: 0 }));
+
+      const result = await detect('pi');
+
+      expect(result).toEqual({
+        installed: true,
+        version: 'pi 0.1.0',
+        authenticated: true,
+        binaryPath: 'pi',
+      });
+    });
+  });
+
   describe('detectAll', () => {
-    it('checks all three CLIs concurrently, returns Record', async () => {
+    it('checks all four CLIs concurrently, returns Record with claude, codex, opencode, pi', async () => {
       // Route mock processes by binary name + args (concurrent calls make queue order unpredictable)
       const { spawn: mockSpawn } = await import('node:child_process');
       const spawnFn = vi.mocked(mockSpawn);
@@ -149,12 +177,18 @@ describe('detect (mocked child_process)', () => {
           if (isVersion) return createEnoentProcess() as any;
           return createMockProcess({ stdoutLines: [], exitCode: 1 }) as any; // shouldn't reach
         }
+        if (bin === 'pi') {
+          // pi only runs version check (optimistic auth)
+          return createMockProcess({ stdoutLines: ['pi 0.1.0'], exitCode: 0 }) as any;
+        }
         // opencode
         if (isVersion) return createMockProcess({ stdoutLines: ['opencode v0.5.0'], exitCode: 0 }) as any;
         return createMockProcess({ stdoutLines: [], exitCode: 1 }) as any; // auth fails
       });
 
       const results = await detectAll();
+
+      expect(Object.keys(results).sort()).toEqual(['claude', 'codex', 'opencode', 'pi']);
 
       expect(results.claude).toEqual({
         installed: true,
@@ -175,6 +209,13 @@ describe('detect (mocked child_process)', () => {
         version: 'opencode v0.5.0',
         authenticated: false,
         binaryPath: 'opencode',
+      });
+
+      expect(results.pi).toEqual({
+        installed: true,
+        version: 'pi 0.1.0',
+        authenticated: true,
+        binaryPath: 'pi',
       });
     });
   });

--- a/test/core/effort.test.ts
+++ b/test/core/effort.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest';
+import { mapEffortToCliFlag } from '../../src/core/effort.js';
+import type { CliName, EffortLevel } from '../../src/types.js';
+
+const ALL_EFFORTS: EffortLevel[] = ['off', 'minimal', 'low', 'medium', 'high', 'max', 'xhigh'];
+
+describe('mapEffortToCliFlag', () => {
+  describe('claude', () => {
+    it('returns null for off and minimal', () => {
+      expect(mapEffortToCliFlag('claude', 'off')).toBeNull();
+      expect(mapEffortToCliFlag('claude', 'minimal')).toBeNull();
+    });
+
+    it('passes through low/medium/high as --effort', () => {
+      expect(mapEffortToCliFlag('claude', 'low')).toEqual({ flag: '--effort', value: 'low' });
+      expect(mapEffortToCliFlag('claude', 'medium')).toEqual({ flag: '--effort', value: 'medium' });
+      expect(mapEffortToCliFlag('claude', 'high')).toEqual({ flag: '--effort', value: 'high' });
+    });
+
+    it('maps max and xhigh to --effort max', () => {
+      expect(mapEffortToCliFlag('claude', 'max')).toEqual({ flag: '--effort', value: 'max' });
+      expect(mapEffortToCliFlag('claude', 'xhigh')).toEqual({ flag: '--effort', value: 'max' });
+    });
+  });
+
+  describe('codex', () => {
+    it('returns null for off and minimal', () => {
+      expect(mapEffortToCliFlag('codex', 'off')).toBeNull();
+      expect(mapEffortToCliFlag('codex', 'minimal')).toBeNull();
+    });
+
+    it('passes through low/medium/high as -c model_reasoning_effort=...', () => {
+      expect(mapEffortToCliFlag('codex', 'low')).toEqual({ flag: '-c', value: 'model_reasoning_effort=low' });
+      expect(mapEffortToCliFlag('codex', 'medium')).toEqual({ flag: '-c', value: 'model_reasoning_effort=medium' });
+      expect(mapEffortToCliFlag('codex', 'high')).toEqual({ flag: '-c', value: 'model_reasoning_effort=high' });
+    });
+
+    it('maps max and xhigh to model_reasoning_effort=high', () => {
+      expect(mapEffortToCliFlag('codex', 'max')).toEqual({ flag: '-c', value: 'model_reasoning_effort=high' });
+      expect(mapEffortToCliFlag('codex', 'xhigh')).toEqual({ flag: '-c', value: 'model_reasoning_effort=high' });
+    });
+  });
+
+  describe('pi', () => {
+    it('passes through off/minimal/low/medium/high as --thinking', () => {
+      expect(mapEffortToCliFlag('pi', 'off')).toEqual({ flag: '--thinking', value: 'off' });
+      expect(mapEffortToCliFlag('pi', 'minimal')).toEqual({ flag: '--thinking', value: 'minimal' });
+      expect(mapEffortToCliFlag('pi', 'low')).toEqual({ flag: '--thinking', value: 'low' });
+      expect(mapEffortToCliFlag('pi', 'medium')).toEqual({ flag: '--thinking', value: 'medium' });
+      expect(mapEffortToCliFlag('pi', 'high')).toEqual({ flag: '--thinking', value: 'high' });
+    });
+
+    it('maps max and xhigh to --thinking xhigh', () => {
+      expect(mapEffortToCliFlag('pi', 'max')).toEqual({ flag: '--thinking', value: 'xhigh' });
+      expect(mapEffortToCliFlag('pi', 'xhigh')).toEqual({ flag: '--thinking', value: 'xhigh' });
+    });
+  });
+
+  describe('opencode', () => {
+    it('returns null for every effort level', () => {
+      for (const effort of ALL_EFFORTS) {
+        expect(mapEffortToCliFlag('opencode', effort)).toBeNull();
+      }
+    });
+  });
+
+  it('covers all 28 (cli, effort) combinations', () => {
+    const clis: CliName[] = ['claude', 'codex', 'opencode', 'pi'];
+    let count = 0;
+    for (const cli of clis) {
+      for (const effort of ALL_EFFORTS) {
+        // exercise to ensure no throw
+        mapEffortToCliFlag(cli, effort);
+        count++;
+      }
+    }
+    expect(count).toBe(28);
+  });
+});

--- a/test/e2e.test.ts
+++ b/test/e2e.test.ts
@@ -25,7 +25,7 @@ import type { CliName, CliEvent, DetectResult } from '../src/index.js';
 // Shared state — resolved at module level so describe.skipIf can use it
 // ---------------------------------------------------------------------------
 
-const CLI_NAMES: CliName[] = ['claude', 'codex', 'opencode'];
+const CLI_NAMES: CliName[] = ['claude', 'codex', 'opencode', 'pi'];
 const installed = await detectAll();
 
 async function collectEvents(iter: AsyncIterable<CliEvent>): Promise<CliEvent[]> {

--- a/test/fixtures/pi/error.jsonl
+++ b/test/fixtures/pi/error.jsonl
@@ -1,0 +1,5 @@
+{"type":"session","id":"pi-sess-err","model":"gpt-5"}
+{"type":"agent_start"}
+{"type":"turn_start"}
+{"type":"message_start","message":{"role":"assistant","model":"gpt-5"}}
+{"type":"message_end","message":{"role":"assistant","stopReason":"error","errorMessage":"upstream provider error"}}

--- a/test/fixtures/pi/malformed.jsonl
+++ b/test/fixtures/pi/malformed.jsonl
@@ -1,0 +1,4 @@
+this is not json
+{"type":"session","id":"pi-sess-malformed","model":"gpt-5"}
+{not valid json either
+plain text line

--- a/test/fixtures/pi/session-resume.jsonl
+++ b/test/fixtures/pi/session-resume.jsonl
@@ -1,0 +1,6 @@
+{"type":"session","id":"pi-sess-resume-xyz","model":"claude-sonnet-4-5"}
+{"type":"agent_start"}
+{"type":"turn_start"}
+{"type":"message_start","message":{"role":"assistant","model":"claude-sonnet-4-5"}}
+{"type":"message_update","assistantMessageEvent":{"type":"text_end","content":"continuing"}}
+{"type":"turn_end","message":{"usage":{"input":150,"output":40,"cost":{"total":0.005}}}}

--- a/test/fixtures/pi/text-response.jsonl
+++ b/test/fixtures/pi/text-response.jsonl
@@ -1,0 +1,8 @@
+{"type":"session","id":"pi-sess-001","model":"gpt-5"}
+{"type":"agent_start"}
+{"type":"turn_start"}
+{"type":"message_start","message":{"role":"assistant","model":"gpt-5"}}
+{"type":"message_update","assistantMessageEvent":{"type":"text_end","content":"Hello from pi!"}}
+{"type":"message_end","message":{"role":"assistant","stopReason":"end","usage":{"input":42,"output":12,"cost":{"total":0.0003}}}}
+{"type":"turn_end","message":{"usage":{"input":42,"output":12,"cost":{"total":0.0003}}}}
+{"type":"agent_end"}

--- a/test/fixtures/pi/tool-result.jsonl
+++ b/test/fixtures/pi/tool-result.jsonl
@@ -1,3 +1,4 @@
+{"type":"session","id":"pi-sess-tools","model":"gpt-5"}
 {"type":"tool_execution_start","toolCallId":"tc-1","toolName":"read_file"}
 {"type":"tool_execution_end","toolCallId":"tc-1","toolName":"read_file","result":{"content":[{"type":"text","text":"file contents here"}]},"isError":false}
 {"type":"tool_execution_start","toolCallId":"tc-2","toolName":"bash"}

--- a/test/fixtures/pi/tool-result.jsonl
+++ b/test/fixtures/pi/tool-result.jsonl
@@ -1,0 +1,4 @@
+{"type":"tool_execution_start","toolCallId":"tc-1","toolName":"read_file"}
+{"type":"tool_execution_end","toolCallId":"tc-1","toolName":"read_file","result":{"content":[{"type":"text","text":"file contents here"}]},"isError":false}
+{"type":"tool_execution_start","toolCallId":"tc-2","toolName":"bash"}
+{"type":"tool_execution_end","toolCallId":"tc-2","toolName":"bash","result":{"content":[{"type":"text","text":"command failed"}]},"isError":true}

--- a/test/fixtures/pi/tool-use.jsonl
+++ b/test/fixtures/pi/tool-use.jsonl
@@ -1,0 +1,6 @@
+{"type":"session","id":"pi-sess-002","model":"gpt-5"}
+{"type":"agent_start"}
+{"type":"turn_start"}
+{"type":"message_start","message":{"role":"assistant","model":"gpt-5"}}
+{"type":"message_update","assistantMessageEvent":{"type":"toolcall_end","toolCall":{"name":"read_file","arguments":{"path":"/src/index.ts"}}}}
+{"type":"message_end","message":{"role":"assistant","stopReason":"tool_use","usage":{"input":80,"output":20,"cost":{"total":0.0007}}}}


### PR DESCRIPTION
## Summary
Adds support for the `pi` coding agent across spawner: adapter implementation, models catalog, detection, effort-to-flag mapping, fixture-based tests, e2e, README, and spec docs.

Closes #16

## Sub-issues
- Closes #17 — Pi adapter core implementation
- Closes #18 — Centralized effort-to-flag mapping module
- Closes #19 — Pi infrastructure wiring (detectAll, listModels, adapter registry)
- Closes #20 — Pi adapter fixture-based tests
- Closes #21 — README, e2e, and spec doc for pi support

## Test plan
- [x] pnpm build
- [x] pnpm lint
- [x] pnpm test (365 tests passing)
- [x] pnpm typecheck