### PR TITLE
Fix Pi text_delta streaming

### DIFF
--- a/src/adapters/pi.ts
+++ b/src/adapters/pi.ts
@@ -124,6 +124,7 @@ export const piAdapter: CliAdapter = {
         if (message?.role === 'assistant') {
           const model = asString(message.model);
           if (model) accumulator.model = model;
+          accumulator.piTextDeltaSeen = false;
         }
         return [];
       }
@@ -134,7 +135,19 @@ export const piAdapter: CliAdapter = {
 
         const eventType = asString(assistantEvent.type);
 
+        if (eventType === 'text_start') {
+          accumulator.piTextDeltaSeen = false;
+          return [];
+        }
+
+        if (eventType === 'text_delta') {
+          accumulator.piTextDeltaSeen = true;
+          const delta = asString(assistantEvent.delta);
+          return [{ type: 'text', content: delta ?? '', timestamp: now, raw: line }];
+        }
+
         if (eventType === 'text_end') {
+          if (accumulator.piTextDeltaSeen) return [];
           const content = asString(assistantEvent.content);
           return [{ type: 'text', content: content ?? '', timestamp: now, raw: line }];
         }

--- a/src/adapters/types.ts
+++ b/src/adapters/types.ts
@@ -14,6 +14,8 @@ export interface SessionAccumulator {
   inputTokens: number;
   outputTokens: number;
   cost: number | null;
+  /** Adapter-specific flag used by pi to suppress duplicate text_end content after streamed deltas. */
+  piTextDeltaSeen?: boolean;
 }
 
 export function createAccumulator(): SessionAccumulator {

--- a/test/adapters/pi.test.ts
+++ b/test/adapters/pi.test.ts
@@ -152,7 +152,7 @@ describe('piAdapter.parseLine', () => {
     expect(events[0].type).toBe('system');
   });
 
-  it('message_update with text_end emits text event', () => {
+  it('message_update with text_end emits text event when no deltas were streamed', () => {
     const line = JSON.stringify({
       type: 'message_update',
       assistantMessageEvent: { type: 'text_end', content: 'Hello world' },
@@ -161,6 +161,41 @@ describe('piAdapter.parseLine', () => {
     expect(events).toHaveLength(1);
     expect(events[0].type).toBe('text');
     expect(events[0].content).toBe('Hello world');
+  });
+
+  it('message_update with text_delta emits incremental text event', () => {
+    const line = JSON.stringify({
+      type: 'message_update',
+      assistantMessageEvent: { type: 'text_delta', delta: 'Hello' },
+    });
+    const events = piAdapter.parseLine(line, acc);
+    expect(events).toHaveLength(1);
+    expect(events[0].type).toBe('text');
+    expect(events[0].content).toBe('Hello');
+  });
+
+  it('skips duplicate text_end content after streamed text_delta events', () => {
+    const lines = [
+      JSON.stringify({ type: 'message_start', message: { role: 'assistant', model: 'gpt-5' } }),
+      JSON.stringify({ type: 'message_update', assistantMessageEvent: { type: 'text_start' } }),
+      JSON.stringify({ type: 'message_update', assistantMessageEvent: { type: 'text_delta', delta: 'Hello' } }),
+      JSON.stringify({ type: 'message_update', assistantMessageEvent: { type: 'text_delta', delta: ' world' } }),
+      JSON.stringify({ type: 'message_update', assistantMessageEvent: { type: 'text_end', content: 'Hello world' } }),
+    ];
+    const events = parseAll(lines, acc).filter((event) => event.type === 'text');
+    expect(events.map((event) => event.content)).toEqual(['Hello', ' world']);
+  });
+
+  it('resets streamed text tracking for a later non-streamed assistant message', () => {
+    const lines = [
+      JSON.stringify({ type: 'message_start', message: { role: 'assistant' } }),
+      JSON.stringify({ type: 'message_update', assistantMessageEvent: { type: 'text_delta', delta: 'streamed' } }),
+      JSON.stringify({ type: 'message_update', assistantMessageEvent: { type: 'text_end', content: 'streamed' } }),
+      JSON.stringify({ type: 'message_start', message: { role: 'assistant' } }),
+      JSON.stringify({ type: 'message_update', assistantMessageEvent: { type: 'text_end', content: 'fallback' } }),
+    ];
+    const events = parseAll(lines, acc).filter((event) => event.type === 'text');
+    expect(events.map((event) => event.content)).toEqual(['streamed', 'fallback']);
   });
 
   it('message_update with toolcall_end emits tool_use event', () => {


### PR DESCRIPTION
Closes #23\n\n## Summary\n- emit normalized text events for Pi text_delta chunks\n- suppress duplicate text_end output after streamed deltas\n- reset streaming state between assistant messages and preserve text_end fallback\n\n## Tests\n- pnpm test\n- pnpm build